### PR TITLE
feat(ui): replace Expo starter with Ding base layout and design tokens

### DIFF
--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,102 +1,157 @@
-import * as Device from 'expo-device';
-import { Platform, StyleSheet } from 'react-native';
+import { StyleSheet, View, Text, TouchableOpacity, ScrollView, Platform } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-
-import { AnimatedIcon } from '@/components/animated-icon';
-import { HintRow } from '@/components/hint-row';
-import { ThemedText } from '@/components/themed-text';
-import { ThemedView } from '@/components/themed-view';
-import { WebBadge } from '@/components/web-badge';
-import { BottomTabInset, MaxContentWidth, Spacing } from '@/constants/theme';
-
-function getDevMenuHint() {
-  if (Platform.OS === 'web') {
-    return <ThemedText type="small">use browser devtools</ThemedText>;
-  }
-  if (Device.isDevice) {
-    return (
-      <ThemedText type="small">
-        shake device or press <ThemedText type="code">m</ThemedText> in terminal
-      </ThemedText>
-    );
-  }
-  const shortcut = Platform.OS === 'android' ? 'cmd+m (or ctrl+m)' : 'cmd+d';
-  return (
-    <ThemedText type="small">
-      press <ThemedText type="code">{shortcut}</ThemedText>
-    </ThemedText>
-  );
-}
+import { useRouter } from 'expo-router';
+import { useTheme } from '@/hooks/use-theme';
+import { Spacing, Radius } from '@/constants/theme';
 
 export default function HomeScreen() {
+  const router = useRouter();
+  const theme = useTheme();
+
   return (
-    <ThemedView style={styles.container}>
-      <SafeAreaView style={styles.safeArea}>
-        <ThemedView style={styles.heroSection}>
-          <AnimatedIcon />
-          <ThemedText type="title" style={styles.title}>
-            Welcome to&nbsp;Expo
-          </ThemedText>
-        </ThemedView>
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <ScrollView contentContainerStyle={styles.container}>
+        {/* Header Section */}
+        <View style={styles.header}>
+          <Text style={[styles.brand, { color: theme.text }]}>Ding</Text>
+          <View style={styles.balanceContainer}>
+            <Text style={[styles.balanceLabel, { color: theme.textSecondary }]}>Total Balance</Text>
+            <Text style={[styles.balanceAmount, { color: theme.text }]}>$1,240.50</Text>
+          </View>
+        </View>
 
-        <ThemedText type="code" style={styles.code}>
-          get started
-        </ThemedText>
+        {/* Primary CTAs */}
+        <View style={styles.actionRow}>
+          <TouchableOpacity 
+            style={[styles.actionButton, { backgroundColor: theme.primary }]}
+            onPress={() => router.push('/send')}
+            activeOpacity={0.8}
+          >
+            <Text style={[styles.actionText, { color: theme.primaryForeground }]}>Send Payment</Text>
+          </TouchableOpacity>
 
-        <ThemedView type="backgroundElement" style={styles.stepContainer}>
-          <HintRow
-            title="Try editing"
-            hint={<ThemedText type="code">src/app/index.tsx</ThemedText>}
-          />
-          <HintRow title="Dev tools" hint={getDevMenuHint()} />
-          <HintRow
-            title="Fresh start"
-            hint={<ThemedText type="code">npm run reset-project</ThemedText>}
-          />
-          <HintRow
-            title="NFC Research"
-            hint={<ThemedText type="code">src/app/nfc-research.tsx</ThemedText>}
-          />
-        </ThemedView>
+          <TouchableOpacity 
+            style={[styles.actionButton, { backgroundColor: theme.card, borderColor: theme.border, borderWidth: 1 }]}
+            onPress={() => router.push('/receive')}
+            activeOpacity={0.8}
+          >
+            <Text style={[styles.actionText, { color: theme.text }]}>Receive Payment</Text>
+          </TouchableOpacity>
+        </View>
 
-        {Platform.OS === 'web' && <WebBadge />}
-      </SafeAreaView>
-    </ThemedView>
+        {/* Recent Activity */}
+        <View style={styles.activitySection}>
+          <Text style={[styles.sectionTitle, { color: theme.text }]}>Recent Activity</Text>
+          
+          <View style={[styles.activityCard, { backgroundColor: theme.card, borderColor: theme.border }]}>
+            <View style={styles.activityItem}>
+              <View style={styles.activityInfo}>
+                <Text style={[styles.activityName, { color: theme.text }]}>Coffee Shop</Text>
+                <Text style={[styles.activityDate, { color: theme.textSecondary }]}>Today, 9:41 AM</Text>
+              </View>
+              <Text style={[styles.activityAmount, { color: theme.text }]}>-$4.50</Text>
+            </View>
+
+            <View style={[styles.divider, { backgroundColor: theme.border }]} />
+
+            <View style={styles.activityItem}>
+              <View style={styles.activityInfo}>
+                <Text style={[styles.activityName, { color: theme.text }]}>Alice Smith</Text>
+                <Text style={[styles.activityDate, { color: theme.textSecondary }]}>Yesterday</Text>
+              </View>
+              <Text style={[styles.activityAmountPositive, { color: theme.primary }]}>+$25.00</Text>
+            </View>
+          </View>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    flexDirection: 'row',
-  },
   safeArea: {
     flex: 1,
-    paddingHorizontal: Spacing.four,
-    alignItems: 'center',
-    gap: Spacing.three,
-    paddingBottom: BottomTabInset + Spacing.three,
-    maxWidth: MaxContentWidth,
   },
-  heroSection: {
+  container: {
+    paddingHorizontal: Spacing.four,
+    paddingTop: Spacing.three,
+    paddingBottom: Spacing.five,
+  },
+  header: {
+    marginBottom: Spacing.five,
+  },
+  brand: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: Spacing.four,
+  },
+  balanceContainer: {
+    marginTop: Spacing.two,
+  },
+  balanceLabel: {
+    fontSize: 14,
+    marginBottom: Spacing.half,
+  },
+  balanceAmount: {
+    fontSize: 36,
+    fontWeight: '800',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: Spacing.three,
+    marginBottom: Spacing.five,
+  },
+  actionButton: {
+    flex: 1,
+    paddingVertical: Spacing.three,
+    borderRadius: Radius.lg,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  actionText: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  activitySection: {
+    marginTop: Spacing.two,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: Spacing.three,
+  },
+  activityCard: {
+    borderRadius: Radius.lg,
+    borderWidth: 1,
+    overflow: 'hidden',
+  },
+  activityItem: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: Spacing.three,
+  },
+  activityInfo: {
     flex: 1,
-    paddingHorizontal: Spacing.four,
-    gap: Spacing.four,
   },
-  title: {
-    textAlign: 'center',
+  activityName: {
+    fontSize: 16,
+    fontWeight: '500',
+    marginBottom: 2,
   },
-  code: {
-    textTransform: 'uppercase',
+  activityDate: {
+    fontSize: 13,
   },
-  stepContainer: {
-    gap: Spacing.three,
-    alignSelf: 'stretch',
-    paddingHorizontal: Spacing.three,
-    paddingVertical: Spacing.four,
-    borderRadius: Spacing.four,
+  activityAmount: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  activityAmountPositive: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  divider: {
+    height: 1,
+    marginHorizontal: Spacing.three,
   },
 });

--- a/src/app/receive.tsx
+++ b/src/app/receive.tsx
@@ -2,16 +2,18 @@ import { StyleSheet, View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '@/hooks/use-theme';
 import { Spacing } from '@/constants/theme';
+import { Stack } from 'expo-router';
 
-export default function ExploreScreen() {
+export default function ReceiveScreen() {
   const theme = useTheme();
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <Stack.Screen options={{ title: 'Receive Payment' }} />
       <View style={styles.container}>
-        <Text style={[styles.title, { color: theme.text }]}>Explore</Text>
+        <Text style={[styles.title, { color: theme.text }]}>Receive Funds</Text>
         <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
-          Discover new ways to manage and spend your funds.
+          Share your address or QR code to receive payments.
         </Text>
       </View>
     </SafeAreaView>
@@ -28,7 +30,7 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.three,
   },
   title: {
-    fontSize: 28,
+    fontSize: 24,
     fontWeight: '700',
     marginBottom: Spacing.two,
   },

--- a/src/app/send.tsx
+++ b/src/app/send.tsx
@@ -2,16 +2,18 @@ import { StyleSheet, View, Text } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useTheme } from '@/hooks/use-theme';
 import { Spacing } from '@/constants/theme';
+import { Stack } from 'expo-router';
 
-export default function ExploreScreen() {
+export default function SendScreen() {
   const theme = useTheme();
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.background }]}>
+      <Stack.Screen options={{ title: 'Send Payment' }} />
       <View style={styles.container}>
-        <Text style={[styles.title, { color: theme.text }]}>Explore</Text>
+        <Text style={[styles.title, { color: theme.text }]}>Send Funds</Text>
         <Text style={[styles.subtitle, { color: theme.textSecondary }]}>
-          Discover new ways to manage and spend your funds.
+          Enter an address or scan a QR code to send payments.
         </Text>
       </View>
     </SafeAreaView>
@@ -28,7 +30,7 @@ const styles = StyleSheet.create({
     paddingTop: Spacing.three,
   },
   title: {
-    fontSize: 28,
+    fontSize: 24,
     fontWeight: '700',
     marginBottom: Spacing.two,
   },

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -9,19 +9,35 @@ import { Platform } from 'react-native';
 
 export const Colors = {
   light: {
-    text: '#000000',
-    background: '#ffffff',
-    backgroundElement: '#F0F0F3',
-    backgroundSelected: '#E0E1E6',
-    textSecondary: '#60646C',
+    text: '#111827',
+    background: '#F9FAFB',
+    backgroundElement: '#FFFFFF',
+    backgroundSelected: '#F3F4F6',
+    textSecondary: '#6B7280',
+    primary: '#4F46E5',
+    primaryForeground: '#FFFFFF',
+    card: '#FFFFFF',
+    border: '#E5E7EB',
   },
   dark: {
-    text: '#ffffff',
-    background: '#000000',
-    backgroundElement: '#212225',
-    backgroundSelected: '#2E3135',
-    textSecondary: '#B0B4BA',
+    text: '#F9FAFB',
+    background: '#030712',
+    backgroundElement: '#111827',
+    backgroundSelected: '#1F2937',
+    textSecondary: '#9CA3AF',
+    primary: '#6366F1',
+    primaryForeground: '#FFFFFF',
+    card: '#111827',
+    border: '#1F2937',
   },
+} as const;
+
+export const Radius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  full: 9999,
 } as const;
 
 export type ThemeColor = keyof typeof Colors.light & keyof typeof Colors.dark;


### PR DESCRIPTION
This PR establishes the core UI visual foundation for the Ding Payments app, pivoting away from the default Expo starter template into a structured, product-focused interface.
- **Design Tokens Framework**: Expanded `theme.ts` to provide robust, semantic color variables (e.g., `primary`, `card`, `border`, `textSecondary`) and standardized boundary radius sizes (`Radius.sm` through `Radius.full`). This ensures predictable rendering across light and dark modes.
- **Product Home Screen**: Fully replaced `src/app/index.tsx` with a new layout that includes a simple branding header, a balance placeholder, primary `Send Payment` and `Receive Payment` CTA buttons, and a mocked Recent Activity feed.
- **Cleaned Up Demo UI**: Stripped all generic Expo onboarding guides and simplified `src/app/explore.tsx` into a clean placeholder.
- **CTA Routing Integration**: Added placeholder screens at `/send` and `/receive` so that the new home screen navigation functions correctly.
### Verification
- Ensure that the primary CTAs successfully route to the placeholder Send/Receive pages.
- Verify that light mode and dark mode styles properly adhere to the newly defined design tokens without any hardcoded discrepancies.
Closes #7 