### PR TITLE
feat(ui): implement MVP send/receive flow screens with mocked states

### DIFF
--- a/src/app/confirmation.tsx
+++ b/src/app/confirmation.tsx
@@ -1,0 +1,57 @@
+import { router } from 'expo-router';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+
+import { FlowStatusCard } from '@/components/flow-status-card';
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+import { MOCK_PAYMENT_REQUEST } from '@/mocks/payment';
+
+export default function ConfirmationScreen() {
+  const req = MOCK_PAYMENT_REQUEST;
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <FlowStatusCard
+          status="success"
+          title="Payment Sent!"
+          description={`${req.amount} ${req.asset} sent to ${req.recipient}`}
+        />
+
+        <ThemedView type="backgroundElement" style={styles.summary}>
+          <ThemedText type="small" themeColor="textSecondary">
+            Transaction ID
+          </ThemedText>
+          <ThemedText type="small" style={styles.txId}>
+            {req.id}
+          </ThemedText>
+        </ThemedView>
+
+        <View style={styles.actions}>
+          <PrimaryActionButton label="Done" onPress={() => router.replace('/')} />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.four,
+    paddingBottom: BottomTabInset + Spacing.four,
+    justifyContent: 'center',
+  },
+  summary: {
+    borderRadius: Spacing.three,
+    padding: Spacing.three,
+    gap: Spacing.one,
+    alignItems: 'center',
+  },
+  txId: { fontWeight: '600' },
+  actions: { gap: Spacing.two },
+});

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,42 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+
+import { FlowStatusCard } from '@/components/flow-status-card';
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+import { ERROR_MESSAGES, ErrorType } from '@/mocks/payment';
+
+export default function ErrorScreen() {
+  const { type } = useLocalSearchParams<{ type: ErrorType }>();
+  const errorType: ErrorType = type ?? 'timeout';
+  const { title, description } = ERROR_MESSAGES[errorType];
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <FlowStatusCard status="error" title={title} description={description} />
+
+        <View style={styles.actions}>
+          {errorType !== 'nfc_unavailable' && (
+            <PrimaryActionButton label="Try Again" onPress={() => router.back()} />
+          )}
+          <SecondaryActionButton label="Go Home" onPress={() => router.replace('/')} />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.four,
+    paddingBottom: BottomTabInset + Spacing.four,
+    justifyContent: 'center',
+  },
+  actions: { gap: Spacing.two },
+});

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,9 +1,12 @@
+import { router } from 'expo-router';
 import * as Device from 'expo-device';
-import { Platform, StyleSheet } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { AnimatedIcon } from '@/components/animated-icon';
 import { HintRow } from '@/components/hint-row';
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { WebBadge } from '@/components/web-badge';
@@ -35,24 +38,32 @@ export default function HomeScreen() {
         <ThemedView style={styles.heroSection}>
           <AnimatedIcon />
           <ThemedText type="title" style={styles.title}>
-            Welcome to&nbsp;Expo
+            Ding Payments
+          </ThemedText>
+          <ThemedText type="small" themeColor="textSecondary" style={styles.subtitle}>
+            Tap-to-pay on Stellar
           </ThemedText>
         </ThemedView>
 
+        <View style={styles.payActions}>
+          <PrimaryActionButton
+            label="Send"
+            onPress={() => router.push('/send')}
+            style={styles.payButton}
+          />
+          <SecondaryActionButton
+            label="Receive"
+            onPress={() => router.push('/receive')}
+            style={styles.payButton}
+          />
+        </View>
+
         <ThemedText type="code" style={styles.code}>
-          get started
+          dev tools
         </ThemedText>
 
         <ThemedView type="backgroundElement" style={styles.stepContainer}>
-          <HintRow
-            title="Try editing"
-            hint={<ThemedText type="code">src/app/index.tsx</ThemedText>}
-          />
-          <HintRow title="Dev tools" hint={getDevMenuHint()} />
-          <HintRow
-            title="Fresh start"
-            hint={<ThemedText type="code">npm run reset-project</ThemedText>}
-          />
+          <HintRow title="Dev menu" hint={getDevMenuHint()} />
           <HintRow
             title="NFC Research"
             hint={<ThemedText type="code">src/app/nfc-research.tsx</ThemedText>}
@@ -84,10 +95,21 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     flex: 1,
     paddingHorizontal: Spacing.four,
-    gap: Spacing.four,
+    gap: Spacing.two,
   },
   title: {
     textAlign: 'center',
+  },
+  subtitle: {
+    textAlign: 'center',
+  },
+  payActions: {
+    flexDirection: 'row',
+    gap: Spacing.three,
+    alignSelf: 'stretch',
+  },
+  payButton: {
+    flex: 1,
   },
   code: {
     textTransform: 'uppercase',

--- a/src/app/receive/_layout.tsx
+++ b/src/app/receive/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function ReceiveLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/src/app/receive/index.tsx
+++ b/src/app/receive/index.tsx
@@ -1,0 +1,64 @@
+import { router } from 'expo-router';
+import { useState } from 'react';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+
+import { AmountInput } from '@/components/amount-input';
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+import { PaymentAsset } from '@/mocks/payment';
+
+export default function ReceiveScreen() {
+  const [amount, setAmount] = useState('');
+  const [asset] = useState<PaymentAsset>('USDC');
+
+  function handleNext() {
+    if (!amount || parseFloat(amount) <= 0) return;
+    router.push('/receive/ready');
+  }
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <ThemedText type="subtitle" style={styles.heading}>
+          Request Payment
+        </ThemedText>
+
+        <ThemedText type="small" themeColor="textSecondary" style={styles.label}>
+          Enter the amount you want to receive
+        </ThemedText>
+
+        <AmountInput
+          asset={asset}
+          value={amount}
+          onChangeText={setAmount}
+          autoFocus
+        />
+
+        <View style={styles.actions}>
+          <PrimaryActionButton
+            label="Next"
+            onPress={handleNext}
+            disabled={!amount || parseFloat(amount) <= 0}
+          />
+          <SecondaryActionButton label="Cancel" onPress={() => router.back()} />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.three,
+    paddingBottom: BottomTabInset + Spacing.four,
+  },
+  heading: { textAlign: 'center', marginTop: Spacing.three },
+  label: { textAlign: 'center' },
+  actions: { gap: Spacing.two, marginTop: 'auto' },
+});

--- a/src/app/receive/ready.tsx
+++ b/src/app/receive/ready.tsx
@@ -1,0 +1,48 @@
+import { router } from 'expo-router';
+import { useEffect } from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+import { FlowStatusCard } from '@/components/flow-status-card';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+
+export default function ReceiveReadyScreen() {
+  // Simulate sender tapping after 3s
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.replace('/confirmation');
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <ThemedText type="subtitle" style={styles.heading}>
+          Ready to Receive
+        </ThemedText>
+
+        <FlowStatusCard
+          status="ready"
+          title="Hold near sender's phone"
+          description="Keep your device close until the payment is confirmed."
+        />
+
+        <SecondaryActionButton label="Cancel" onPress={() => router.back()} />
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.four,
+    paddingBottom: BottomTabInset + Spacing.four,
+  },
+  heading: { textAlign: 'center', marginTop: Spacing.three },
+});

--- a/src/app/send/_layout.tsx
+++ b/src/app/send/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function SendLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/src/app/send/confirm.tsx
+++ b/src/app/send/confirm.tsx
@@ -1,0 +1,65 @@
+import { router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+import { FlowStatusCard } from '@/components/flow-status-card';
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+
+type Stage = 'passkey' | 'submitting';
+
+export default function SendConfirmScreen() {
+  const [stage, setStage] = useState<Stage>('passkey');
+
+  function handlePasskey() {
+    setStage('submitting');
+  }
+
+  useEffect(() => {
+    if (stage !== 'submitting') return;
+    const timer = setTimeout(() => {
+      router.replace('/confirmation');
+    }, 1800);
+    return () => clearTimeout(timer);
+  }, [stage]);
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <ThemedText type="subtitle" style={styles.heading}>
+          Authorize Payment
+        </ThemedText>
+
+        {stage === 'passkey' ? (
+          <>
+            <FlowStatusCard
+              status="ready"
+              title="Authenticate to send"
+              description="Use Face ID / Touch ID to sign and broadcast the transaction."
+            />
+            <PrimaryActionButton label="Authenticate with Passkey" onPress={handlePasskey} />
+          </>
+        ) : (
+          <FlowStatusCard
+            status="waiting"
+            title="Submitting…"
+            description="Broadcasting transaction to the Stellar network."
+          />
+        )}
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.four,
+    paddingBottom: BottomTabInset + Spacing.four,
+  },
+  heading: { textAlign: 'center', marginTop: Spacing.three },
+});

--- a/src/app/send/index.tsx
+++ b/src/app/send/index.tsx
@@ -1,0 +1,48 @@
+import { router } from 'expo-router';
+import { useEffect } from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
+
+import { FlowStatusCard } from '@/components/flow-status-card';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+
+export default function SendWaitingScreen() {
+  // Simulate receiving a payment request after 2.5s
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.replace('/send/review');
+    }, 2500);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <ThemedText type="subtitle" style={styles.heading}>
+          Send Payment
+        </ThemedText>
+
+        <FlowStatusCard
+          status="waiting"
+          title="Waiting for request…"
+          description="Hold your device near the recipient's phone to receive their payment request."
+        />
+
+        <SecondaryActionButton label="Cancel" onPress={() => router.back()} />
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.four,
+    paddingBottom: BottomTabInset + Spacing.four,
+  },
+  heading: { textAlign: 'center', marginTop: Spacing.three },
+});

--- a/src/app/send/review.tsx
+++ b/src/app/send/review.tsx
@@ -1,0 +1,108 @@
+import { router } from 'expo-router';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+
+import { PrimaryActionButton } from '@/components/primary-action-button';
+import { SecondaryActionButton } from '@/components/secondary-action-button';
+import { ThemedText } from '@/components/themed-text';
+import { ThemedView } from '@/components/themed-view';
+import { BottomTabInset, Spacing } from '@/constants/theme';
+import { MOCK_BALANCE, MOCK_PAYMENT_REQUEST } from '@/mocks/payment';
+
+function ReviewRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={styles.row}>
+      <ThemedText type="small" themeColor="textSecondary">
+        {label}
+      </ThemedText>
+      <ThemedText type="small" style={styles.rowValue}>
+        {value}
+      </ThemedText>
+    </View>
+  );
+}
+
+export default function SendReviewScreen() {
+  const req = MOCK_PAYMENT_REQUEST;
+  const balance = MOCK_BALANCE[req.asset];
+  const hasBalance = parseFloat(balance) >= parseFloat(req.amount);
+
+  function handleConfirm() {
+    if (!hasBalance) {
+      router.replace({ pathname: '/error', params: { type: 'insufficient_balance' } });
+    } else {
+      router.replace('/send/confirm');
+    }
+  }
+
+  return (
+    <ThemedView style={styles.container}>
+      <SafeAreaView style={styles.inner}>
+        <ThemedText type="subtitle" style={styles.heading}>
+          Review Payment
+        </ThemedText>
+
+        <ThemedView type="backgroundElement" style={styles.card}>
+          <ThemedText style={styles.amount}>
+            {req.amount} {req.asset}
+          </ThemedText>
+          <ThemedText type="small" themeColor="textSecondary">
+            to {req.recipient}
+          </ThemedText>
+        </ThemedView>
+
+        <ThemedView type="backgroundElement" style={styles.details}>
+          <ReviewRow label="Recipient" value={req.recipient} />
+          <ReviewRow label="Address" value={req.recipientAddress} />
+          <ReviewRow label="Asset" value={req.asset} />
+          {req.memo ? <ReviewRow label="Memo" value={req.memo} /> : null}
+          <ReviewRow label="Your balance" value={`${balance} ${req.asset}`} />
+        </ThemedView>
+
+        {!hasBalance && (
+          <ThemedText type="small" style={styles.warning}>
+            ⚠️ Insufficient balance
+          </ThemedText>
+        )}
+
+        <View style={styles.actions}>
+          <PrimaryActionButton
+            label={hasBalance ? 'Confirm & Send' : 'Insufficient Balance'}
+            onPress={handleConfirm}
+          />
+          <SecondaryActionButton label="Cancel" onPress={() => router.back()} />
+        </View>
+      </SafeAreaView>
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  inner: {
+    flex: 1,
+    padding: Spacing.four,
+    gap: Spacing.three,
+    paddingBottom: BottomTabInset + Spacing.four,
+  },
+  heading: { textAlign: 'center', marginTop: Spacing.three },
+  card: {
+    borderRadius: Spacing.four,
+    padding: Spacing.four,
+    alignItems: 'center',
+    gap: Spacing.one,
+  },
+  amount: { fontSize: 40, fontWeight: '700' },
+  details: {
+    borderRadius: Spacing.three,
+    padding: Spacing.three,
+    gap: Spacing.two,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingVertical: Spacing.one,
+  },
+  rowValue: { fontWeight: '600' },
+  warning: { color: '#f59e0b', textAlign: 'center' },
+  actions: { gap: Spacing.two, marginTop: 'auto' },
+});

--- a/src/components/amount-input.tsx
+++ b/src/components/amount-input.tsx
@@ -1,0 +1,49 @@
+import { StyleSheet, TextInput, View, type TextInputProps } from 'react-native';
+
+import { Spacing } from '@/constants/theme';
+import { useTheme } from '@/hooks/use-theme';
+import { ThemedText } from './themed-text';
+import { PaymentAsset } from '@/mocks/payment';
+
+type Props = TextInputProps & {
+  asset: PaymentAsset;
+  onAssetPress?: () => void;
+};
+
+export function AmountInput({ asset, style, ...props }: Props) {
+  const theme = useTheme();
+  return (
+    <View style={[styles.container, { backgroundColor: theme.backgroundElement }]}>
+      <TextInput
+        style={[styles.input, { color: theme.text }]}
+        keyboardType="decimal-pad"
+        placeholder="0.00"
+        placeholderTextColor={theme.textSecondary}
+        accessibilityLabel="Payment amount"
+        {...props}
+      />
+      <ThemedText style={styles.asset}>{asset}</ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: Spacing.three,
+    paddingHorizontal: Spacing.three,
+    paddingVertical: Spacing.two,
+    gap: Spacing.two,
+  },
+  input: {
+    flex: 1,
+    fontSize: 36,
+    fontWeight: '600',
+    minHeight: 52,
+  },
+  asset: {
+    fontSize: 20,
+    fontWeight: '600',
+  },
+});

--- a/src/components/flow-status-card.tsx
+++ b/src/components/flow-status-card.tsx
@@ -1,0 +1,64 @@
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
+
+import { Spacing } from '@/constants/theme';
+import { useTheme } from '@/hooks/use-theme';
+import { ThemedText } from './themed-text';
+import { ThemedView } from './themed-view';
+
+type Status = 'waiting' | 'success' | 'error' | 'ready';
+
+type Props = {
+  status: Status;
+  title: string;
+  description?: string;
+};
+
+const STATUS_ICON: Record<Status, string> = {
+  waiting: '📡',
+  ready: '📲',
+  success: '✅',
+  error: '❌',
+};
+
+export function FlowStatusCard({ status, title, description }: Props) {
+  const theme = useTheme();
+  return (
+    <ThemedView type="backgroundElement" style={styles.card}>
+      <View style={[styles.iconCircle, { backgroundColor: theme.backgroundSelected }]}>
+        {status === 'waiting' ? (
+          <ActivityIndicator size="large" color="#3c87f7" />
+        ) : (
+          <ThemedText style={styles.icon}>{STATUS_ICON[status]}</ThemedText>
+        )}
+      </View>
+      <ThemedText type="subtitle" style={styles.title}>
+        {title}
+      </ThemedText>
+      {description ? (
+        <ThemedText type="small" themeColor="textSecondary" style={styles.description}>
+          {description}
+        </ThemedText>
+      ) : null}
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: Spacing.four,
+    padding: Spacing.four,
+    alignItems: 'center',
+    gap: Spacing.three,
+    alignSelf: 'stretch',
+  },
+  iconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  icon: { fontSize: 36 },
+  title: { textAlign: 'center' },
+  description: { textAlign: 'center' },
+});

--- a/src/components/primary-action-button.tsx
+++ b/src/components/primary-action-button.tsx
@@ -1,0 +1,31 @@
+import { Pressable, StyleSheet, type PressableProps } from 'react-native';
+
+import { Spacing } from '@/constants/theme';
+import { ThemedText } from './themed-text';
+
+type Props = PressableProps & { label: string };
+
+export function PrimaryActionButton({ label, style, ...props }: Props) {
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.button, pressed && styles.pressed, style as object]}
+      accessibilityRole="button"
+      {...props}>
+      <ThemedText style={styles.label}>{label}</ThemedText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#3c87f7',
+    borderRadius: Spacing.three,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    alignItems: 'center',
+    minHeight: 52,
+    justifyContent: 'center',
+  },
+  pressed: { opacity: 0.75 },
+  label: { color: '#fff', fontWeight: '700', fontSize: 16 },
+});

--- a/src/components/secondary-action-button.tsx
+++ b/src/components/secondary-action-button.tsx
@@ -1,0 +1,38 @@
+import { Pressable, StyleSheet, type PressableProps } from 'react-native';
+
+import { Spacing } from '@/constants/theme';
+import { ThemedText } from './themed-text';
+import { useTheme } from '@/hooks/use-theme';
+
+type Props = PressableProps & { label: string };
+
+export function SecondaryActionButton({ label, style, ...props }: Props) {
+  const theme = useTheme();
+  return (
+    <Pressable
+      style={({ pressed }) => [
+        styles.button,
+        { borderColor: theme.backgroundSelected },
+        pressed && styles.pressed,
+        style as object,
+      ]}
+      accessibilityRole="button"
+      {...props}>
+      <ThemedText style={styles.label}>{label}</ThemedText>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    borderWidth: 1.5,
+    borderRadius: Spacing.three,
+    paddingVertical: Spacing.three,
+    paddingHorizontal: Spacing.four,
+    alignItems: 'center',
+    minHeight: 52,
+    justifyContent: 'center',
+  },
+  pressed: { opacity: 0.6 },
+  label: { fontWeight: '600', fontSize: 16 },
+});

--- a/src/mocks/payment.ts
+++ b/src/mocks/payment.ts
@@ -1,0 +1,43 @@
+export type PaymentAsset = 'XLM' | 'USDC';
+
+export type PaymentRequest = {
+  id: string;
+  amount: string;
+  asset: PaymentAsset;
+  recipient: string;
+  recipientAddress: string;
+  memo?: string;
+  createdAt: string;
+};
+
+export type ErrorType = 'nfc_unavailable' | 'timeout' | 'insufficient_balance';
+
+export const MOCK_PAYMENT_REQUEST: PaymentRequest = {
+  id: 'pay_mock_001',
+  amount: '12.50',
+  asset: 'USDC',
+  recipient: 'Alice',
+  recipientAddress: 'GBXXX...1234',
+  memo: 'Coffee ☕',
+  createdAt: new Date().toISOString(),
+};
+
+export const MOCK_BALANCE = {
+  XLM: '245.00',
+  USDC: '8.30',
+};
+
+export const ERROR_MESSAGES: Record<ErrorType, { title: string; description: string }> = {
+  nfc_unavailable: {
+    title: 'NFC Unavailable',
+    description: 'NFC is not available on this device. Use QR code instead.',
+  },
+  timeout: {
+    title: 'Connection Timed Out',
+    description: 'No device was detected nearby. Please try again.',
+  },
+  insufficient_balance: {
+    title: 'Insufficient Balance',
+    description: "You don't have enough funds to complete this payment.",
+  },
+};


### PR DESCRIPTION
Closes #8

---

## Summary

Implements the core MVP payment flow UI with mocked data to validate navigation, screen hierarchy, and state handling end-to-end.

## Changes

**New screens**
- `send/index` — waiting for NFC request (auto-advances with mock after 2.5s)
- `send/review` — shows payment request details + balance check
- `send/confirm` — passkey auth placeholder → submitting state
- `receive/index` — amount input
- `receive/ready` — hold-near-sender state (auto-advances after 3s)
- `confirmation` — success screen with transaction summary
- `error` — handles `nfc_unavailable`, `timeout`, `insufficient_balance` via route param

**New components**
- `AmountInput` — numeric input with asset label
- `FlowStatusCard` — status card with spinner/icon, title, description
- `PrimaryActionButton` / `SecondaryActionButton` — reused across all flows

**Mock data** (`src/mocks/payment.ts`) — `PaymentRequest` type, mock request, balances, error messages

**Updated** `src/app/index.tsx` — Home screen now has Send and Receive as primary actions

## Out of scope
- Real NFC, Stellar transactions, or passkey signing (all mocked/placeholder)