### PR TITLE
feat(receive): implement C12 end-to-end receive payment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ See [docs/adr-nfc-library.md](docs/adr-nfc-library.md) for platform constraints 
 - [Product flows & system definition](docs/ding-payments.md)
 - [Client MVP build plan](docs/build-plan-client-mvp.md)
 - [NFC library ADR](docs/adr-nfc-library.md)
+- [Receive payment flow (C12)](docs/receive-flow.md)
 
 ## License
 

--- a/docs/receive-flow.md
+++ b/docs/receive-flow.md
@@ -1,0 +1,111 @@
+# Receive Payment Flow (C12)
+
+The receive flow lets a user request a contactless payment: enter an amount,
+broadcast a payment request over NFC, wait for the payer's on-chain payment,
+and land on a success or failure screen. It is implemented as an explicit
+finite-state machine (FSM) orchestrated by `useReceivePayment` and shared
+across screens via `ReceivePaymentProvider`.
+
+## 1. State diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> preparing: prepare(amount, asset, recipientPublicKey)
+    preparing --> failed: trustline check fails (USDC only)
+    preparing --> broadcasting: startBroadcast()
+    broadcasting --> waiting: NFC writer reports success\n(payload delivered to payer)
+    broadcasting --> failed: NFC writer reports error
+    broadcasting --> cancelled: cancel() / request expiry
+    waiting --> success: confirmSuccess(txHash?)
+    waiting --> failed: confirmFailure(reason) / 60s wait timeout
+    waiting --> cancelled: cancel()
+    success --> idle: reset() ("Receive Another")
+    failed --> idle: reset() ("Try Again" / "Change Amount")
+    cancelled --> idle: reset()
+```
+
+Note: NFC delivery success is **not** the same as payment success — it only
+means the request payload reached the payer's device. That's why
+`broadcasting` moves to `waiting` (not `success`) once the NFC writer session
+completes; `waiting` is resolved only by an explicit `confirmSuccess` /
+`confirmFailure` call (today: the 60-second wait timeout in
+`WaitingForPaymentView`; a future iteration can resolve it early via balance
+polling).
+
+## 2. File map
+
+| File | Responsibility |
+| --- | --- |
+| `src/features/receive/schemas/receiveAmount.ts` | Zod validation for the amount + asset pair (CLI-062) |
+| `src/features/receive/services/PaymentRequestBuilder.ts` | Builds a `PaymentRequest` via the shared `createPaymentRequest` (CLI-063) |
+| `src/features/receive/services/receiveSession.ts` | Owns the request-expiry and wait-timeout timers, cancellable and ghost-free (CLI-069) |
+| `src/features/wallet/services/TrustlineService.ts` | Checks whether the receiver has a USDC trustline before a USDC request is broadcast (CLI-070) |
+| `src/features/receive/hooks/useReceivePayment.ts` | FSM orchestrator + `ReceivePaymentProvider`/`useReceivePaymentContext` for cross-screen state (CLI-065) |
+| `src/features/receive/views/ReceiveHomeView.tsx` | Amount entry, asset selector, kicks off `prepare()` (CLI-061) |
+| `src/features/receive/views/ReceiveListeningView.tsx` | Starts the NFC broadcast, shows countdown + NFC status (CLI-064) |
+| `src/features/receive/views/WaitingForPaymentView.tsx` | Waits for payment settlement, 60s timeout (CLI-066) |
+| `src/features/receive/views/ReceiveSuccessView.tsx` | Success summary, reset/home actions (CLI-067) |
+| `src/features/receive/views/ReceiveFailedView.tsx` | Error-specific messaging, retry/change-amount actions (CLI-068) |
+| `src/constants/analytics-events.ts` | Receive funnel event names + sanitized property shape (CLI-071) |
+| `src/app/receive/{listening,waiting,success,failed}.tsx` | Expo Router screens for each non-home view |
+| `src/app/(tabs)/receive.tsx` | Tab entry point, renders `ReceiveHomeView` |
+| `src/app/_layout.tsx` | Mounts `ReceivePaymentProvider` above all routes so orchestrator state survives navigation |
+
+## 3. Timeout model
+
+Two independent timers, both owned by `ReceiveSessionManager` (`receiveSession`):
+
+- **Request expiry** — `startRequestExpiry(expiresAtSeconds, onExpire)`. Started
+  in `startBroadcast()` using the `PaymentRequest.expiresAt` timestamp set at
+  build time (`DEFAULT_EXPIRY_TTL_SECONDS = 5 * 60`, i.e. 5 minutes from
+  `prepare()`). If the broadcast is still active when the request expires, the
+  orchestrator cancels the session (`cancel()`).
+- **Wait timeout** — `startWaitTimeout(ms, onTimeout)`. Started by
+  `WaitingForPaymentView` when it mounts (`WAIT_TIMEOUT_MS = 60_000`). If no
+  success/failure confirmation arrives within 60 seconds, the view calls
+  `confirmFailure('timeout')`.
+
+**Interaction**: request expiry only matters while broadcasting (the payer
+hasn't tapped yet); wait timeout only matters after the NFC handoff succeeded
+and we're waiting on settlement. They are mutually exclusive by construction —
+`startBroadcast()` cancels any prior expiry timer before starting a new one,
+and `cancel()` / `reset()` always call `receiveSession.cancelAll()` so no timer
+outlives its screen.
+
+## 4. Error matrix
+
+| Error code | Screen shown | User message | Recovery action |
+| --- | --- | --- | --- |
+| `timeout` | `ReceiveFailedView` | "Payment timed out. Please try again." | Try Again (same amount) or Change Amount |
+| `nfc_error` | `ReceiveFailedView` | "NFC connection was lost." | Try Again (same amount) or Change Amount |
+| `trustline_missing` | `ReceiveFailedView` | "USDC trustline not found. Set up your USDC account first." | Try Again (same amount) or Change Amount |
+| *(anything else)* | `ReceiveFailedView` | "Payment failed. Please try again." | Try Again (same amount) or Change Amount |
+
+"Try Again" preserves the previously entered amount/asset by forwarding them as
+route params back to `ReceiveHomeView`; "Change Amount" resets fully and
+returns to a blank form.
+
+## 5. Analytics event mapping
+
+All receive events live in `AnalyticsEvents` (`src/constants/analytics-events.ts`)
+and carry only sanitized properties — **no public keys, no raw amounts, no
+PII**. Amounts are bucketed via `amount_bucket`: `'<1' | '1-10' | '10-100' | '>100'`.
+
+| State transition | Event | Sanitized properties |
+| --- | --- | --- |
+| `idle` → `preparing` (`prepare()` called) | `RECEIVE_STARTED` | `amount_bucket`, `asset` |
+| `preparing` → `broadcasting` (`startBroadcast()`) | `RECEIVE_BROADCAST` | `amount_bucket`, `asset` |
+| `broadcasting` → `waiting` (NFC write succeeded) | `RECEIVE_WAITING` | `amount_bucket`, `asset` |
+| `waiting`/`broadcasting` → `success` (`confirmSuccess()`) | `RECEIVE_COMPLETED` | `amount_bucket`, `asset` |
+| any → `failed` (`confirmFailure(reason)`) | `RECEIVE_FAILED` | `amount_bucket`, `asset`, `reason` |
+| any → `cancelled` (`cancel()`) | `RECEIVE_CANCELLED` | `amount_bucket`, `asset` |
+
+## 6. Related docs
+
+- [NFC library ADR](adr-nfc-library.md) — payload size/encoding constraints the
+  payment request payload must respect.
+- [Product flows & system definition](ding-payments.md) — payment payload
+  structure this flow builds on.
+- [Client MVP build plan](build-plan-client-mvp.md) — where C12 sits in the
+  overall build.

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import { AnimatedSplashOverlay } from '@/components/animated-icon';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AuthProvider } from '@/features/auth/hooks/useAuth';
 import { SessionPolicyMount } from '@/features/auth/components/SessionPolicyMount';
+import { ReceivePaymentProvider } from '@/features/receive/hooks/useReceivePayment';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
@@ -15,12 +16,20 @@ export default function RootLayout() {
         <AuthProvider>
           <SessionPolicyMount />
           <AnimatedSplashOverlay />
-          <Stack screenOptions={{ headerShown: false }}>
-            <Stack.Screen name="index" />
-            <Stack.Screen name="(tabs)" />
-            <Stack.Screen name="(onboarding)" />
-            <Stack.Screen name="c05" />
-          </Stack>
+          {/*
+            ReceivePaymentProvider wraps every route so the FSM orchestrator
+            (CLI-065) survives navigation between (tabs)/receive and the
+            receive/* screens — Expo Router unmounts/remounts screens on
+            navigation, so a per-screen hook instance would lose state.
+          */}
+          <ReceivePaymentProvider>
+            <Stack screenOptions={{ headerShown: false }}>
+              <Stack.Screen name="index" />
+              <Stack.Screen name="(tabs)" />
+              <Stack.Screen name="(onboarding)" />
+              <Stack.Screen name="c05" />
+            </Stack>
+          </ReceivePaymentProvider>
         </AuthProvider>
       </ErrorBoundary>
     </ThemeProvider>

--- a/src/app/receive/failed.tsx
+++ b/src/app/receive/failed.tsx
@@ -1,0 +1,5 @@
+import { ReceiveFailedView } from '@/features/receive/views/ReceiveFailedView';
+
+export default function ReceiveFailedScreen() {
+  return <ReceiveFailedView />;
+}

--- a/src/app/receive/listening.tsx
+++ b/src/app/receive/listening.tsx
@@ -1,0 +1,5 @@
+import { ReceiveListeningView } from '@/features/receive/views/ReceiveListeningView';
+
+export default function ReceiveListeningScreen() {
+  return <ReceiveListeningView />;
+}

--- a/src/app/receive/success.tsx
+++ b/src/app/receive/success.tsx
@@ -1,0 +1,5 @@
+import { ReceiveSuccessView } from '@/features/receive/views/ReceiveSuccessView';
+
+export default function ReceiveSuccessScreen() {
+  return <ReceiveSuccessView />;
+}

--- a/src/app/receive/waiting.tsx
+++ b/src/app/receive/waiting.tsx
@@ -1,0 +1,5 @@
+import { WaitingForPaymentView } from '@/features/receive/views/WaitingForPaymentView';
+
+export default function ReceiveWaitingScreen() {
+  return <WaitingForPaymentView />;
+}

--- a/src/constants/analytics-events.ts
+++ b/src/constants/analytics-events.ts
@@ -4,6 +4,28 @@ export const AnalyticsEvents = {
   SEND_OPENED: 'send_opened',
   HISTORY_OPENED: 'history_opened',
   SETTINGS_OPENED: 'settings_opened',
+
+  // Receive funnel (CLI-071) — see docs/receive-flow.md
+  RECEIVE_STARTED: 'receive_started',
+  RECEIVE_BROADCAST: 'receive_broadcast',
+  RECEIVE_WAITING: 'receive_waiting',
+  RECEIVE_COMPLETED: 'receive_completed',
+  RECEIVE_FAILED: 'receive_failed',
+  RECEIVE_CANCELLED: 'receive_cancelled',
 } as const;
 
 export type AnalyticsEventName = (typeof AnalyticsEvents)[keyof typeof AnalyticsEvents];
+
+/**
+ * Amount bucket used in receive funnel events instead of raw amounts.
+ * Never log a raw amount, public key, or other PII in an analytics payload.
+ */
+export type AmountBucket = '<1' | '1-10' | '10-100' | '>100';
+
+/** Allowed properties for receive funnel events. No pubkeys, no raw amounts, no PII. */
+export interface ReceiveEventProperties {
+  amount_bucket: AmountBucket;
+  asset: string;
+  reason?: string;
+  duration_ms?: number;
+}

--- a/src/features/receive/__tests__/PaymentRequestBuilder.test.ts
+++ b/src/features/receive/__tests__/PaymentRequestBuilder.test.ts
@@ -1,0 +1,66 @@
+import {
+  DEFAULT_EXPIRY_TTL_SECONDS,
+  PaymentRequestBuilder,
+} from '@/features/receive/services/PaymentRequestBuilder';
+
+const VALID_RECIPIENT = 'GBBD47IF6LWK7P7MUGHC2XLYUUXV6ZLW75PN7CHLIW2NSIW74UZEST66';
+
+describe('PaymentRequestBuilder', () => {
+  it('returns a valid PaymentRequest shape', () => {
+    const builder = new PaymentRequestBuilder();
+
+    const request = builder.build({
+      amount: '25.50',
+      asset: 'USDC',
+      recipientPublicKey: VALID_RECIPIENT,
+    });
+
+    expect(request).toMatchObject({
+      type: 'payment_request',
+      recipient: VALID_RECIPIENT,
+      asset: 'USDC',
+      amount: '25.50',
+    });
+    expect(typeof request.timestamp).toBe('number');
+    expect(typeof request.expiresAt).toBe('number');
+  });
+
+  it('sets expiresAt to timestamp + DEFAULT_EXPIRY_TTL_SECONDS', () => {
+    const builder = new PaymentRequestBuilder();
+
+    const request = builder.build({
+      amount: '10',
+      asset: 'XLM',
+      recipientPublicKey: VALID_RECIPIENT,
+    });
+
+    expect(request.expiresAt - request.timestamp).toBe(DEFAULT_EXPIRY_TTL_SECONDS);
+    expect(DEFAULT_EXPIRY_TTL_SECONDS).toBe(5 * 60);
+  });
+
+  it('produces correct type/recipient/asset/amount across repeated calls', () => {
+    const builder = new PaymentRequestBuilder();
+
+    const first = builder.build({
+      amount: '1',
+      asset: 'XLM',
+      recipientPublicKey: VALID_RECIPIENT,
+    });
+    const second = builder.build({
+      amount: '1',
+      asset: 'XLM',
+      recipientPublicKey: VALID_RECIPIENT,
+    });
+
+    // createPaymentRequest derives its timestamp from Date.now(), not a uuid,
+    // so two calls within the same second may be identical — what must hold
+    // is that every field is internally consistent and well-formed.
+    for (const request of [first, second]) {
+      expect(request.type).toBe('payment_request');
+      expect(request.recipient).toBe(VALID_RECIPIENT);
+      expect(request.asset).toBe('XLM');
+      expect(request.amount).toBe('1');
+      expect(request.expiresAt).toBeGreaterThan(request.timestamp);
+    }
+  });
+});

--- a/src/features/receive/__tests__/receiveAmount.test.ts
+++ b/src/features/receive/__tests__/receiveAmount.test.ts
@@ -1,0 +1,53 @@
+import { receiveAmountSchema } from '@/features/receive/schemas/receiveAmount';
+
+describe('receiveAmountSchema', () => {
+  it('accepts a valid XLM amount', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '125.1234567', asset: 'XLM' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid USDC amount with 2 decimal places', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '25.50', asset: 'USDC' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects USDC amounts with 3 decimal places', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '25.123', asset: 'USDC' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts XLM amounts with up to 7 decimal places (not capped at 2)', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '1.1234567', asset: 'XLM' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a zero amount', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '0', asset: 'XLM' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a negative amount string', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '-1', asset: 'XLM' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects amounts greater than the maximum', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '1000000', asset: 'XLM' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts the maximum amount exactly', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '999999', asset: 'XLM' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-numeric string', () => {
+    const result = receiveAmountSchema.safeParse({ amount: 'abc', asset: 'XLM' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unsupported asset', () => {
+    const result = receiveAmountSchema.safeParse({ amount: '10', asset: 'BTC' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/features/receive/__tests__/receiveSession.test.ts
+++ b/src/features/receive/__tests__/receiveSession.test.ts
@@ -1,0 +1,63 @@
+import { ReceiveSessionManager } from '@/features/receive/services/receiveSession';
+
+describe('ReceiveSessionManager', () => {
+  let manager: ReceiveSessionManager;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    manager = new ReceiveSessionManager();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('startRequestExpiry fires onExpire once the expiry timestamp is reached', () => {
+    const onExpire = jest.fn();
+
+    manager.startRequestExpiry(5, onExpire);
+
+    jest.advanceTimersByTime(4_999);
+    expect(onExpire).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+
+  it('the cancel function returned by startRequestExpiry prevents onExpire from firing', () => {
+    const onExpire = jest.fn();
+
+    const cancel = manager.startRequestExpiry(5, onExpire);
+    cancel();
+
+    jest.advanceTimersByTime(10_000);
+    expect(onExpire).not.toHaveBeenCalled();
+  });
+
+  it('cancelAll() stops every active timer', () => {
+    const onExpire = jest.fn();
+    const onTimeout = jest.fn();
+
+    manager.startRequestExpiry(5, onExpire);
+    manager.startWaitTimeout(3_000, onTimeout);
+
+    manager.cancelAll();
+
+    jest.advanceTimersByTime(60_000);
+    expect(onExpire).not.toHaveBeenCalled();
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it('startWaitTimeout fires onTimeout after the given delay', () => {
+    const onTimeout = jest.fn();
+
+    manager.startWaitTimeout(60_000, onTimeout);
+
+    jest.advanceTimersByTime(59_999);
+    expect(onTimeout).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/receive/__tests__/useReceivePayment.test.ts
+++ b/src/features/receive/__tests__/useReceivePayment.test.ts
@@ -1,0 +1,183 @@
+import { createElement } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { useReceivePayment } from '@/features/receive/hooks/useReceivePayment';
+
+const VALID_RECIPIENT = 'GBBD47IF6LWK7P7MUGHC2XLYUUXV6ZLW75PN7CHLIW2NSIW74UZEST66';
+
+const FIXED_REQUEST = {
+  type: 'payment_request' as const,
+  recipient: VALID_RECIPIENT,
+  asset: 'XLM',
+  amount: '5',
+  timestamp: 1_000,
+  expiresAt: 1_300,
+};
+
+// ─── Mocks ──────────────────────────────────────────────────────────────────
+
+let mockNfcStatus: 'idle' | 'scanning' | 'writing' | 'success' | 'error' = 'idle';
+const mockNfcStartWriting = jest.fn(async () => {
+  mockNfcStatus = 'writing';
+});
+const mockNfcCancel = jest.fn(async () => {
+  mockNfcStatus = 'idle';
+});
+
+jest.mock('@/features/nfc/hooks/useNfcWriter', () => ({
+  useNfcWriter: () => ({
+    status: mockNfcStatus,
+    error: null,
+    startWriting: mockNfcStartWriting,
+    cancel: mockNfcCancel,
+  }),
+}));
+
+const mockCancelExpiryTimer = jest.fn();
+const mockStartRequestExpiry = jest.fn(() => mockCancelExpiryTimer);
+const mockStartWaitTimeout = jest.fn(() => jest.fn());
+const mockCancelAll = jest.fn();
+
+jest.mock('@/features/receive/services/receiveSession', () => ({
+  receiveSession: {
+    startRequestExpiry: (...args: unknown[]) =>
+      (mockStartRequestExpiry as (...a: unknown[]) => () => void)(...args),
+    startWaitTimeout: (...args: unknown[]) =>
+      (mockStartWaitTimeout as (...a: unknown[]) => () => void)(...args),
+    cancelAll: () => mockCancelAll(),
+  },
+}));
+
+const mockBuild = jest.fn(() => FIXED_REQUEST);
+jest.mock('@/features/receive/services/PaymentRequestBuilder', () => ({
+  paymentRequestBuilder: {
+    build: (...args: unknown[]) =>
+      (mockBuild as (...a: unknown[]) => typeof FIXED_REQUEST)(...args),
+  },
+}));
+
+const mockCheckUsdcTrustline = jest.fn(async () => ({ hasLine: true, sufficientReserve: true }));
+jest.mock('@/features/wallet/services/TrustlineService', () => ({
+  trustlineService: {
+    checkUsdcTrustline: (...args: unknown[]) =>
+      (mockCheckUsdcTrustline as (...a: unknown[]) => Promise<unknown>)(...args),
+  },
+}));
+
+const mockTrackEvent = jest.fn();
+jest.mock('@/lib/analytics', () => ({
+  trackEvent: (...args: unknown[]) => (mockTrackEvent as (...a: unknown[]) => void)(...args),
+}));
+
+// ─── Minimal renderHook harness (no @testing-library/react-native installed) ──
+
+function renderHookHarness<T>(callback: () => T) {
+  const result: { current: T } = { current: undefined as unknown as T };
+
+  function TestComponent() {
+    result.current = callback();
+    return null;
+  }
+
+  let renderer!: ReactTestRenderer;
+  act(() => {
+    renderer = create(createElement(TestComponent));
+  });
+
+  return {
+    result,
+    rerender: () => act(() => renderer.update(createElement(TestComponent))),
+    unmount: () => act(() => renderer.unmount()),
+  };
+}
+
+describe('useReceivePayment', () => {
+  beforeEach(() => {
+    mockNfcStatus = 'idle';
+    jest.clearAllMocks();
+    mockBuild.mockReturnValue(FIXED_REQUEST);
+    mockCheckUsdcTrustline.mockResolvedValue({ hasLine: true, sufficientReserve: true });
+    mockStartRequestExpiry.mockReturnValue(mockCancelExpiryTimer);
+  });
+
+  it('transitions idle -> preparing -> broadcasting -> waiting -> success', async () => {
+    const { result, rerender } = renderHookHarness(() => useReceivePayment());
+
+    expect(result.current.state).toBe('idle');
+
+    await act(async () => {
+      await result.current.prepare('5', 'XLM', VALID_RECIPIENT);
+    });
+    expect(result.current.state).toBe('preparing');
+    expect(result.current.paymentRequest).toEqual(FIXED_REQUEST);
+
+    await act(async () => {
+      await result.current.startBroadcast();
+    });
+    expect(mockNfcStartWriting).toHaveBeenCalledWith(FIXED_REQUEST);
+
+    // The NFC mock flips status to 'writing' synchronously and stays there
+    // until we simulate a successful delivery below.
+    mockNfcStatus = 'success';
+    rerender();
+    expect(result.current.state).toBe('waiting');
+
+    act(() => {
+      result.current.confirmSuccess('abc123');
+    });
+    expect(result.current.state).toBe('success');
+    expect(result.current.txHash).toBe('abc123');
+  });
+
+  it('cancels from the broadcasting state', async () => {
+    const { result } = renderHookHarness(() => useReceivePayment());
+
+    await act(async () => {
+      await result.current.prepare('5', 'XLM', VALID_RECIPIENT);
+    });
+    await act(async () => {
+      await result.current.startBroadcast();
+    });
+    expect(result.current.state).toBe('broadcasting');
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    expect(result.current.state).toBe('cancelled');
+    expect(mockNfcCancel).toHaveBeenCalled();
+    expect(mockCancelAll).toHaveBeenCalled();
+  });
+
+  it('moves to failed with the given reason on the timeout path', async () => {
+    const { result } = renderHookHarness(() => useReceivePayment());
+
+    await act(async () => {
+      await result.current.prepare('5', 'XLM', VALID_RECIPIENT);
+    });
+    await act(async () => {
+      await result.current.startBroadcast();
+    });
+
+    act(() => {
+      result.current.confirmFailure('timeout');
+    });
+
+    expect(result.current.state).toBe('failed');
+    expect(result.current.error).toBe('timeout');
+  });
+
+  it('fails preparation with trustline_missing when the USDC trustline check fails', async () => {
+    mockCheckUsdcTrustline.mockResolvedValueOnce({ hasLine: false, sufficientReserve: false });
+    const { result } = renderHookHarness(() => useReceivePayment());
+
+    await act(async () => {
+      await expect(result.current.prepare('5', 'USDC', VALID_RECIPIENT)).rejects.toThrow(
+        'trustline_missing'
+      );
+    });
+
+    expect(result.current.state).toBe('failed');
+    expect(result.current.error).toBe('trustline_missing');
+  });
+});

--- a/src/features/receive/hooks/useReceivePayment.ts
+++ b/src/features/receive/hooks/useReceivePayment.ts
@@ -1,0 +1,260 @@
+/**
+ * Receive payment FSM orchestrator (CLI-065).
+ *
+ * States: idle -> preparing -> broadcasting -> waiting -> success | failed | cancelled.
+ *
+ * NFC delivery success (the writer session completing) is not the same as
+ * payment success — it only means the request payload reached the payer's
+ * device. That is why `broadcasting` moves to `waiting` automatically once
+ * the NFC writer reports success, and a separate `confirmSuccess` /
+ * `confirmFailure` call is what actually resolves the flow once the payment
+ * (or its absence) has been confirmed.
+ *
+ * @see docs/receive-flow.md — state diagram, timeout model, error matrix
+ */
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { AnalyticsEvents, type AmountBucket } from '@/constants/analytics-events';
+import { useNfcWriter } from '@/features/nfc/hooks/useNfcWriter';
+import type { PaymentRequest } from '@/features/nfc/schemas/paymentRequest';
+import { paymentRequestBuilder } from '@/features/receive/services/PaymentRequestBuilder';
+import { receiveSession } from '@/features/receive/services/receiveSession';
+import { trustlineService } from '@/features/wallet/services/TrustlineService';
+import type { SupportedAssetCode } from '@/features/wallet/constants/assets';
+import { trackEvent } from '@/lib/analytics';
+
+export type ReceiveState =
+  | 'idle'
+  | 'preparing'
+  | 'broadcasting'
+  | 'waiting'
+  | 'success'
+  | 'failed'
+  | 'cancelled';
+
+export interface UseReceivePaymentResult {
+  state: ReceiveState;
+  paymentRequest: PaymentRequest | null;
+  error: string | null;
+  txHash: string | null;
+  nfcStatus: ReturnType<typeof useNfcWriter>['status'];
+  prepare: (amount: string, asset: SupportedAssetCode, recipientPublicKey: string) => Promise<void>;
+  startBroadcast: () => Promise<void>;
+  cancel: () => Promise<void>;
+  confirmSuccess: (txHash?: string) => void;
+  confirmFailure: (reason: string) => void;
+  reset: () => void;
+}
+
+/** Buckets a raw amount into a non-identifying range for analytics. Never log the raw amount. */
+function amountBucket(amount: string): AmountBucket {
+  const value = parseFloat(amount);
+  if (value < 1) return '<1';
+  if (value < 10) return '1-10';
+  if (value < 100) return '10-100';
+  return '>100';
+}
+
+export function useReceivePayment(): UseReceivePaymentResult {
+  // `phase` never includes 'waiting' — that's derived below rather than
+  // stored, so the transition doesn't require calling setState from inside
+  // an Effect (see https://react.dev/learn/you-might-not-need-an-effect).
+  const [phase, setPhase] = useState<Exclude<ReceiveState, 'waiting'>>('idle');
+  const [paymentRequest, setPaymentRequest] = useState<PaymentRequest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [txHash, setTxHash] = useState<string | null>(null);
+
+  // Internal-only bookkeeping that is never read during render (only from
+  // event handlers/effects), so it's safe to keep as a ref.
+  const assetRef = useRef<string>('XLM');
+  const cancelExpiryRef = useRef<(() => void) | null>(null);
+  const waitingEmittedRef = useRef(false);
+
+  const nfcWriter = useNfcWriter();
+
+  // NFC delivery success only means the request payload reached the payer's
+  // device — the receiver still has to wait for the on-chain payment, hence
+  // deriving 'waiting' instead of the NFC writer's 'success' bleeding through.
+  const state: ReceiveState =
+    phase === 'broadcasting' && nfcWriter.status === 'success' ? 'waiting' : phase;
+
+  const cancelExpiryTimer = useCallback(() => {
+    cancelExpiryRef.current?.();
+    cancelExpiryRef.current = null;
+  }, []);
+
+  const confirmFailure = useCallback(
+    (reason: string) => {
+      cancelExpiryTimer();
+      setError(reason);
+      setPhase('failed');
+      trackEvent(AnalyticsEvents.RECEIVE_FAILED, {
+        amount_bucket: paymentRequest
+          ? amountBucket(paymentRequest.amount)
+          : ('<1' as AmountBucket),
+        asset: assetRef.current,
+        reason,
+      });
+    },
+    [cancelExpiryTimer, paymentRequest]
+  );
+
+  const confirmSuccess = useCallback(
+    (txHashArg?: string) => {
+      cancelExpiryTimer();
+      setError(null);
+      setTxHash(txHashArg ?? null);
+      setPhase('success');
+      trackEvent(AnalyticsEvents.RECEIVE_COMPLETED, {
+        amount_bucket: paymentRequest
+          ? amountBucket(paymentRequest.amount)
+          : ('<1' as AmountBucket),
+        asset: assetRef.current,
+      });
+    },
+    [cancelExpiryTimer, paymentRequest]
+  );
+
+  const cancel = useCallback(async () => {
+    cancelExpiryTimer();
+    receiveSession.cancelAll();
+    await nfcWriter.cancel();
+    setPhase('cancelled');
+    trackEvent(AnalyticsEvents.RECEIVE_CANCELLED, {
+      amount_bucket: paymentRequest ? amountBucket(paymentRequest.amount) : ('<1' as AmountBucket),
+      asset: assetRef.current,
+    });
+  }, [cancelExpiryTimer, nfcWriter, paymentRequest]);
+
+  const prepare = useCallback(
+    async (amount: string, asset: SupportedAssetCode, recipientPublicKey: string) => {
+      setError(null);
+      assetRef.current = asset;
+      setPhase('preparing');
+      trackEvent(AnalyticsEvents.RECEIVE_STARTED, {
+        amount_bucket: amountBucket(amount),
+        asset,
+      });
+
+      try {
+        if (asset === 'USDC') {
+          const { hasLine } = await trustlineService.checkUsdcTrustline(recipientPublicKey);
+          if (!hasLine) {
+            throw new Error('trustline_missing');
+          }
+        }
+
+        const request = paymentRequestBuilder.build({ amount, asset, recipientPublicKey });
+        setPaymentRequest(request);
+        setPhase('preparing');
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : 'unknown';
+        confirmFailure(reason);
+        throw err;
+      }
+    },
+    [confirmFailure]
+  );
+
+  const startBroadcast = useCallback(async () => {
+    if (!paymentRequest) {
+      throw new Error('Cannot start broadcast before prepare() has built a payment request');
+    }
+
+    setPhase('broadcasting');
+    trackEvent(AnalyticsEvents.RECEIVE_BROADCAST, {
+      amount_bucket: amountBucket(paymentRequest.amount),
+      asset: assetRef.current,
+    });
+
+    cancelExpiryTimer();
+    cancelExpiryRef.current = receiveSession.startRequestExpiry(paymentRequest.expiresAt, () => {
+      void cancel();
+    });
+
+    await nfcWriter.startWriting(paymentRequest);
+  }, [cancel, cancelExpiryTimer, nfcWriter, paymentRequest]);
+
+  const reset = useCallback(() => {
+    cancelExpiryTimer();
+    receiveSession.cancelAll();
+    void nfcWriter.cancel();
+    setPaymentRequest(null);
+    setError(null);
+    setTxHash(null);
+    setPhase('idle');
+  }, [cancelExpiryTimer, nfcWriter]);
+
+  // Emits RECEIVE_WAITING exactly once per transition into the derived
+  // 'waiting' state. This only performs a side effect (analytics) — it never
+  // calls a state setter, so it doesn't trigger cascading renders.
+  useEffect(() => {
+    if (state === 'waiting') {
+      if (!waitingEmittedRef.current) {
+        waitingEmittedRef.current = true;
+        trackEvent(AnalyticsEvents.RECEIVE_WAITING, {
+          amount_bucket: paymentRequest
+            ? amountBucket(paymentRequest.amount)
+            : ('<1' as AmountBucket),
+          asset: assetRef.current,
+        });
+      }
+    } else {
+      waitingEmittedRef.current = false;
+    }
+  }, [state, paymentRequest]);
+
+  useEffect(() => {
+    return () => {
+      cancelExpiryTimer();
+    };
+  }, [cancelExpiryTimer]);
+
+  return {
+    state,
+    paymentRequest,
+    error,
+    txHash,
+    nfcStatus: nfcWriter.status,
+    prepare,
+    startBroadcast,
+    cancel,
+    confirmSuccess,
+    confirmFailure,
+    reset,
+  };
+}
+
+// ─── Shared instance across route navigations ──────────────────────────────
+//
+// Expo Router unmounts/remounts each screen on navigation, so the receive
+// flow spans multiple screens (home -> listening -> waiting -> success/failed)
+// that each need to see the *same* orchestrator state. ReceivePaymentProvider
+// calls useReceivePayment() exactly once and shares it via context; mount it
+// above every route that participates in the receive flow (see
+// src/app/_layout.tsx). Call useReceivePaymentContext() from views instead of
+// calling useReceivePayment() directly.
+
+const ReceivePaymentContext = createContext<UseReceivePaymentResult | null>(null);
+
+export function ReceivePaymentProvider({ children }: { children: ReactNode }) {
+  const value = useReceivePayment();
+  return createElement(ReceivePaymentContext.Provider, { value }, children);
+}
+
+export function useReceivePaymentContext(): UseReceivePaymentResult {
+  const context = useContext(ReceivePaymentContext);
+  if (!context) {
+    throw new Error('useReceivePaymentContext must be used within a ReceivePaymentProvider');
+  }
+  return context;
+}

--- a/src/features/receive/schemas/receiveAmount.ts
+++ b/src/features/receive/schemas/receiveAmount.ts
@@ -1,0 +1,43 @@
+/**
+ * Receive amount validation (CLI-062).
+ *
+ * @see docs/receive-flow.md — timeout model and error matrix
+ */
+import { z } from 'zod';
+
+/** Decimal amount string (up to 7 fractional digits) — matches paymentRequest's AMOUNT_REGEX. */
+const AMOUNT_REGEX = /^\d+(\.\d{1,7})?$/;
+
+/** Largest amount a receive request may ask for. */
+export const MAX_RECEIVE_AMOUNT = 999_999;
+
+/** Maximum fractional digits accepted for USDC amounts. */
+const USDC_MAX_DECIMALS = 2;
+
+export const RECEIVE_AMOUNT_ERRORS = {
+  invalidFormat: 'Enter a valid amount using digits and up to 7 decimal places.',
+  tooSmall: 'Amount must be greater than zero.',
+  tooLarge: `Amount cannot exceed ${MAX_RECEIVE_AMOUNT.toLocaleString('en-US')}.`,
+  usdcPrecision: `USDC amounts support up to ${USDC_MAX_DECIMALS} decimal places.`,
+  unsupportedAsset: 'Select a supported asset (XLM or USDC).',
+} as const;
+
+function decimalPlaces(amount: string): number {
+  return amount.includes('.') ? amount.split('.')[1].length : 0;
+}
+
+export const receiveAmountSchema = z
+  .object({
+    amount: z
+      .string()
+      .regex(AMOUNT_REGEX, RECEIVE_AMOUNT_ERRORS.invalidFormat)
+      .refine((value) => parseFloat(value) > 0, RECEIVE_AMOUNT_ERRORS.tooSmall)
+      .refine((value) => parseFloat(value) <= MAX_RECEIVE_AMOUNT, RECEIVE_AMOUNT_ERRORS.tooLarge),
+    asset: z.enum(['XLM', 'USDC'], { message: RECEIVE_AMOUNT_ERRORS.unsupportedAsset }),
+  })
+  .refine((data) => data.asset !== 'USDC' || decimalPlaces(data.amount) <= USDC_MAX_DECIMALS, {
+    message: RECEIVE_AMOUNT_ERRORS.usdcPrecision,
+    path: ['amount'],
+  });
+
+export type ReceiveAmountInput = z.infer<typeof receiveAmountSchema>;

--- a/src/features/receive/services/PaymentRequestBuilder.ts
+++ b/src/features/receive/services/PaymentRequestBuilder.ts
@@ -1,0 +1,32 @@
+/**
+ * Builds NFC-broadcastable payment requests for the receive flow (CLI-063).
+ *
+ * @see src/features/nfc/schemas/paymentRequest.ts — canonical payment_request.v1 payload
+ * @see docs/receive-flow.md — timeout model
+ */
+import { createPaymentRequest, type PaymentRequest } from '@/features/nfc/schemas/paymentRequest';
+import type { SupportedAssetCode } from '@/features/wallet/constants/assets';
+
+export type { PaymentRequest };
+
+/** Default time-to-live for a receive request before it expires (5 minutes). */
+export const DEFAULT_EXPIRY_TTL_SECONDS = 5 * 60;
+
+export interface BuildPaymentRequestInput {
+  amount: string;
+  asset: SupportedAssetCode;
+  recipientPublicKey: string;
+}
+
+export class PaymentRequestBuilder {
+  build({ amount, asset, recipientPublicKey }: BuildPaymentRequestInput): PaymentRequest {
+    return createPaymentRequest({
+      recipient: recipientPublicKey,
+      asset,
+      amount,
+      ttlSeconds: DEFAULT_EXPIRY_TTL_SECONDS,
+    });
+  }
+}
+
+export const paymentRequestBuilder = new PaymentRequestBuilder();

--- a/src/features/receive/services/receiveSession.ts
+++ b/src/features/receive/services/receiveSession.ts
@@ -1,0 +1,54 @@
+/**
+ * Timer coordination for the receive flow (CLI-069).
+ *
+ * Owns the two timers the receive FSM depends on: request expiry (how long a
+ * broadcast payment request stays valid) and wait timeout (how long we wait
+ * for the payer's transaction after broadcasting). All timers are tracked so
+ * `cancelAll()` can guarantee no ghost timers outlive a cancelled/reset session.
+ *
+ * @see docs/receive-flow.md — timeout model
+ */
+
+type CancelFn = () => void;
+
+export class ReceiveSessionManager {
+  private timers = new Set<ReturnType<typeof setTimeout>>();
+
+  /**
+   * Starts a timer that fires `onExpire` when `expiresAtSeconds` (unix seconds,
+   * matching PaymentRequest.expiresAt) is reached. Returns a cancel function.
+   */
+  startRequestExpiry(expiresAtSeconds: number, onExpire: () => void): CancelFn {
+    const delayMs = Math.max(0, expiresAtSeconds * 1000 - Date.now());
+    return this.schedule(delayMs, onExpire);
+  }
+
+  /** Starts a timer that fires `onTimeout` after `ms` milliseconds. */
+  startWaitTimeout(ms: number, onTimeout: () => void): CancelFn {
+    return this.schedule(ms, onTimeout);
+  }
+
+  /** Cancels every timer currently tracked by this manager. */
+  cancelAll(): void {
+    for (const timer of this.timers) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+  }
+
+  private schedule(delayMs: number, callback: () => void): CancelFn {
+    const timer = setTimeout(() => {
+      this.timers.delete(timer);
+      callback();
+    }, delayMs);
+
+    this.timers.add(timer);
+
+    return () => {
+      clearTimeout(timer);
+      this.timers.delete(timer);
+    };
+  }
+}
+
+export const receiveSession = new ReceiveSessionManager();

--- a/src/features/receive/views/ReceiveFailedView.tsx
+++ b/src/features/receive/views/ReceiveFailedView.tsx
@@ -1,0 +1,72 @@
+/**
+ * Receive failure screen (CLI-068).
+ *
+ * @see docs/receive-flow.md — error matrix
+ */
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { Button, Screen } from '@/components/ui';
+import { Spacing } from '@/constants/theme';
+import { useReceivePaymentContext } from '@/features/receive/hooks/useReceivePayment';
+
+const ERROR_MESSAGES: Record<string, string> = {
+  timeout: 'Payment timed out. Please try again.',
+  nfc_error: 'NFC connection was lost.',
+  trustline_missing: 'USDC trustline not found. Set up your USDC account first.',
+};
+
+const DEFAULT_MESSAGE = 'Payment failed. Please try again.';
+
+export const ReceiveFailedView = () => {
+  const router = useRouter();
+  const { error, paymentRequest, reset } = useReceivePaymentContext();
+
+  const message = (error && ERROR_MESSAGES[error]) ?? DEFAULT_MESSAGE;
+
+  const handleTryAgain = () => {
+    const amount = paymentRequest?.amount;
+    const asset = paymentRequest?.asset;
+    reset();
+    router.replace({
+      pathname: '/(tabs)/receive',
+      params: amount && asset ? { amount, asset } : undefined,
+    });
+  };
+
+  const handleChangeAmount = () => {
+    reset();
+    router.replace('/(tabs)/receive');
+  };
+
+  return (
+    <Screen>
+      <View style={styles.body}>
+        <ThemedText type="title" themeColor="error">
+          ✕
+        </ThemedText>
+        <ThemedText type="subtitle">Payment failed</ThemedText>
+        <ThemedText themeColor="textSecondary">{message}</ThemedText>
+      </View>
+
+      <View style={styles.actions}>
+        <Button label="Try Again" onPress={handleTryAgain} />
+        <Button label="Change Amount" variant="secondary" onPress={handleChangeAmount} />
+      </View>
+    </Screen>
+  );
+};
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.two,
+  },
+  actions: {
+    gap: Spacing.two,
+    marginBottom: Spacing.four,
+  },
+});

--- a/src/features/receive/views/ReceiveHomeView.tsx
+++ b/src/features/receive/views/ReceiveHomeView.tsx
@@ -1,19 +1,160 @@
-import { useEffect } from 'react';
+/**
+ * Receive amount entry (CLI-061).
+ *
+ * @see docs/receive-flow.md
+ */
+import { useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 
 import { ThemedText } from '@/components/themed-text';
-import { Screen } from '@/components/ui';
+import { Button, Screen, TextInput } from '@/components/ui';
 import { AnalyticsEvents } from '@/constants/analytics-events';
+import { Spacing } from '@/constants/theme';
+import { useAuth } from '@/features/auth/hooks/useAuth';
+import { receiveAmountSchema } from '@/features/receive/schemas/receiveAmount';
+import { useReceivePaymentContext } from '@/features/receive/hooks/useReceivePayment';
+import {
+  isSupportedAssetCode,
+  SUPPORTED_ASSET_CODES,
+  type SupportedAssetCode,
+} from '@/features/wallet/constants/assets';
+import { useTheme } from '@/hooks/use-theme';
 import { trackEvent } from '@/lib/analytics';
 
 export const ReceiveHomeView = () => {
+  const theme = useTheme();
+  const router = useRouter();
+  const { state: authState } = useAuth();
+  const { prepare } = useReceivePaymentContext();
+
+  // "Try Again" (CLI-068) forwards the previous amount/asset via route params
+  // so the receiver doesn't have to retype them after a failure.
+  const params = useLocalSearchParams<{ amount?: string; asset?: string }>();
+  const initialAsset: SupportedAssetCode =
+    typeof params.asset === 'string' && isSupportedAssetCode(params.asset) ? params.asset : 'XLM';
+
+  const [amount, setAmount] = useState(typeof params.amount === 'string' ? params.amount : '');
+  const [asset, setAsset] = useState<SupportedAssetCode>(initialAsset);
+  const [submitting, setSubmitting] = useState(false);
+
   useEffect(() => {
     trackEvent(AnalyticsEvents.RECEIVE_OPENED);
   }, []);
 
+  const validation = useMemo(
+    () => receiveAmountSchema.safeParse({ amount, asset }),
+    [amount, asset]
+  );
+
+  const inlineError =
+    amount.length > 0 && !validation.success ? validation.error.issues[0]?.message : undefined;
+
+  const canSubmit = validation.success && !submitting && Boolean(authState.publicKey);
+
+  const handleSubmit = async () => {
+    if (!validation.success || !authState.publicKey) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await prepare(validation.data.amount, validation.data.asset, authState.publicKey);
+      router.push('/receive/listening');
+    } catch {
+      router.push('/receive/failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   return (
-    <Screen>
+    <Screen scrollable>
       <ThemedText type="subtitle">Receive</ThemedText>
-      <ThemedText themeColor="textSecondary">Accept contactless payment requests here.</ThemedText>
+      <ThemedText themeColor="textSecondary">
+        Enter an amount and hold your phone near the payer to broadcast a request.
+      </ThemedText>
+
+      <View style={styles.field}>
+        <ThemedText type="smallBold">Amount</ThemedText>
+        <TextInput
+          value={amount}
+          onChangeText={setAmount}
+          placeholder="0.00"
+          keyboardType="decimal-pad"
+          accessibilityLabel="Amount to receive"
+        />
+        {inlineError ? (
+          <ThemedText themeColor="error" type="small">
+            {inlineError}
+          </ThemedText>
+        ) : null}
+      </View>
+
+      <View style={styles.field}>
+        <ThemedText type="smallBold">Asset</ThemedText>
+        <View style={styles.assetRow}>
+          {SUPPORTED_ASSET_CODES.map((code) => {
+            const selected = code === asset;
+            return (
+              <Pressable
+                key={code}
+                accessibilityRole="button"
+                accessibilityState={{ selected }}
+                onPress={() => setAsset(code)}
+                style={[
+                  styles.assetPill,
+                  {
+                    backgroundColor: selected ? theme.primary : theme.backgroundElement,
+                    borderColor: selected ? theme.primary : theme.backgroundSelected,
+                  },
+                ]}
+              >
+                <ThemedText
+                  type="smallBold"
+                  style={selected ? styles.assetPillLabelSelected : undefined}
+                >
+                  {code}
+                </ThemedText>
+              </Pressable>
+            );
+          })}
+        </View>
+      </View>
+
+      <Button
+        label="Start Receiving"
+        onPress={handleSubmit}
+        disabled={!canSubmit}
+        loading={submitting}
+        style={styles.submit}
+      />
     </Screen>
   );
 };
+
+const styles = StyleSheet.create({
+  field: {
+    marginTop: Spacing.four,
+    gap: Spacing.two,
+  },
+  assetRow: {
+    flexDirection: 'row',
+    gap: Spacing.two,
+  },
+  assetPill: {
+    flex: 1,
+    minHeight: 44,
+    borderWidth: 1,
+    borderRadius: Spacing.three,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: Spacing.two,
+  },
+  assetPillLabelSelected: {
+    color: '#FFFFFF',
+  },
+  submit: {
+    marginTop: Spacing.five,
+  },
+});

--- a/src/features/receive/views/ReceiveListeningView.tsx
+++ b/src/features/receive/views/ReceiveListeningView.tsx
@@ -1,0 +1,110 @@
+/**
+ * NFC broadcast screen (CLI-064) — starts writing the payment request on
+ * mount and shows a countdown until the request expires.
+ *
+ * @see docs/receive-flow.md
+ */
+import { useEffect, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { Button, Screen } from '@/components/ui';
+import { Spacing } from '@/constants/theme';
+import { useReceivePaymentContext } from '@/features/receive/hooks/useReceivePayment';
+
+const NFC_STATUS_LABELS: Record<string, string> = {
+  idle: 'Preparing…',
+  writing: 'Hold your phone near the payer…',
+  success: 'Request delivered',
+  error: 'NFC connection lost',
+  scanning: 'Preparing…',
+};
+
+function formatCountdown(secondsRemaining: number): string {
+  const clamped = Math.max(0, secondsRemaining);
+  const minutes = Math.floor(clamped / 60);
+  const seconds = clamped % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export const ReceiveListeningView = () => {
+  const router = useRouter();
+  const { state, paymentRequest, nfcStatus, startBroadcast, cancel, confirmFailure } =
+    useReceivePaymentContext();
+
+  const [secondsRemaining, setSecondsRemaining] = useState(0);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+    void startBroadcast();
+  }, [startBroadcast]);
+
+  useEffect(() => {
+    if (!paymentRequest) {
+      return;
+    }
+
+    const tick = () => {
+      setSecondsRemaining(Math.max(0, paymentRequest.expiresAt - Math.floor(Date.now() / 1000)));
+    };
+
+    tick();
+    const interval = setInterval(tick, 1_000);
+    return () => clearInterval(interval);
+  }, [paymentRequest]);
+
+  useEffect(() => {
+    if (state === 'waiting') {
+      router.replace('/receive/waiting');
+    }
+  }, [state, router]);
+
+  useEffect(() => {
+    if (nfcStatus === 'error') {
+      confirmFailure('nfc_error');
+    }
+  }, [nfcStatus, confirmFailure]);
+
+  useEffect(() => {
+    if (state === 'failed') {
+      router.replace('/receive/failed');
+    }
+  }, [state, router]);
+
+  const handleCancel = async () => {
+    await cancel();
+    router.replace('/(tabs)/receive');
+  };
+
+  return (
+    <Screen>
+      <ThemedText type="subtitle">Waiting to connect</ThemedText>
+
+      <View style={styles.body}>
+        <ThemedText type="title">{formatCountdown(secondsRemaining)}</ThemedText>
+        <ThemedText themeColor="textSecondary">
+          {NFC_STATUS_LABELS[nfcStatus] ?? 'Preparing…'}
+        </ThemedText>
+      </View>
+
+      <Button label="Cancel" variant="secondary" onPress={handleCancel} style={styles.cancel} />
+    </Screen>
+  );
+};
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.two,
+  },
+  cancel: {
+    marginBottom: Spacing.four,
+  },
+});

--- a/src/features/receive/views/ReceiveSuccessView.tsx
+++ b/src/features/receive/views/ReceiveSuccessView.tsx
@@ -1,0 +1,74 @@
+/**
+ * Receive success screen (CLI-067).
+ *
+ * RECEIVE_COMPLETED is emitted by the orchestrator's confirmSuccess() at the
+ * moment of the state transition — this view only renders the result, it
+ * does not re-emit the event (that would double-count the funnel step).
+ *
+ * @see docs/receive-flow.md
+ */
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { Button, Screen } from '@/components/ui';
+import { Spacing } from '@/constants/theme';
+import { useReceivePaymentContext } from '@/features/receive/hooks/useReceivePayment';
+
+function truncateHash(hash: string): string {
+  if (hash.length <= 12) {
+    return hash;
+  }
+  return `${hash.slice(0, 6)}…${hash.slice(-6)}`;
+}
+
+export const ReceiveSuccessView = () => {
+  const router = useRouter();
+  const { paymentRequest, txHash, reset } = useReceivePaymentContext();
+
+  const handleReceiveAnother = () => {
+    reset();
+    router.replace('/(tabs)/receive');
+  };
+
+  const handleDone = () => {
+    router.replace('/(tabs)/receive');
+  };
+
+  return (
+    <Screen>
+      <View style={styles.body}>
+        <ThemedText type="title">✓</ThemedText>
+        <ThemedText type="subtitle">Payment received</ThemedText>
+        {paymentRequest ? (
+          <ThemedText themeColor="textSecondary">
+            {paymentRequest.amount} {paymentRequest.asset}
+          </ThemedText>
+        ) : null}
+        {txHash ? (
+          <ThemedText type="code" themeColor="textSecondary">
+            {truncateHash(txHash)}
+          </ThemedText>
+        ) : null}
+      </View>
+
+      <View style={styles.actions}>
+        <Button label="Receive Another" onPress={handleReceiveAnother} />
+        <Button label="Done" variant="secondary" onPress={handleDone} />
+      </View>
+    </Screen>
+  );
+};
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.two,
+  },
+  actions: {
+    gap: Spacing.two,
+    marginBottom: Spacing.four,
+  },
+});

--- a/src/features/receive/views/WaitingForPaymentView.tsx
+++ b/src/features/receive/views/WaitingForPaymentView.tsx
@@ -1,0 +1,88 @@
+/**
+ * Waiting for the payer's on-chain payment to settle (CLI-066).
+ *
+ * NOTE: balance-delta polling is out of scope for the MVP — this screen only
+ * tracks elapsed time and times out after 60 seconds. A future iteration can
+ * poll wallet balance every few seconds and resolve early via confirmSuccess()
+ * once the expected delta is observed.
+ *
+ * @see docs/receive-flow.md
+ */
+import { useEffect, useRef, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { ThemedText } from '@/components/themed-text';
+import { Button, LoadingSpinner, Screen } from '@/components/ui';
+import { Spacing } from '@/constants/theme';
+import { useReceivePaymentContext } from '@/features/receive/hooks/useReceivePayment';
+import { receiveSession } from '@/features/receive/services/receiveSession';
+
+const WAIT_TIMEOUT_MS = 60_000;
+
+export const WaitingForPaymentView = () => {
+  const router = useRouter();
+  const { state, cancel, confirmFailure } = useReceivePaymentContext();
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const timeoutStartedRef = useRef(false);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsedSeconds((prev) => prev + 1);
+    }, 1_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (timeoutStartedRef.current) {
+      return;
+    }
+    timeoutStartedRef.current = true;
+
+    const cancelTimeout = receiveSession.startWaitTimeout(WAIT_TIMEOUT_MS, () => {
+      confirmFailure('timeout');
+    });
+
+    return cancelTimeout;
+  }, [confirmFailure]);
+
+  useEffect(() => {
+    if (state === 'success') {
+      router.replace('/receive/success');
+    } else if (state === 'failed') {
+      router.replace('/receive/failed');
+    } else if (state === 'cancelled') {
+      router.replace('/(tabs)/receive');
+    }
+  }, [state, router]);
+
+  const handleCancel = async () => {
+    await cancel();
+    router.replace('/(tabs)/receive');
+  };
+
+  return (
+    <Screen>
+      <ThemedText type="subtitle">Waiting for payment…</ThemedText>
+
+      <View style={styles.body}>
+        <LoadingSpinner />
+        <ThemedText themeColor="textSecondary">{elapsedSeconds}s elapsed</ThemedText>
+      </View>
+
+      <Button label="Cancel" variant="secondary" onPress={handleCancel} style={styles.cancel} />
+    </Screen>
+  );
+};
+
+const styles = StyleSheet.create({
+  body: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: Spacing.three,
+  },
+  cancel: {
+    marginBottom: Spacing.four,
+  },
+});

--- a/src/features/wallet/services/TrustlineService.ts
+++ b/src/features/wallet/services/TrustlineService.ts
@@ -1,0 +1,45 @@
+/**
+ * USDC trustline checks (CLI-070).
+ *
+ * The receive flow must confirm the receiver already has a USDC trustline
+ * before broadcasting a USDC payment request over NFC — a payer cannot send
+ * an asset the receiver has no line for.
+ *
+ * @see docs/receive-flow.md — error matrix (trustline_missing)
+ */
+import { Horizon } from '@stellar/stellar-sdk';
+
+import { env } from '@/lib/env';
+
+export interface TrustlineCheckResult {
+  hasLine: boolean;
+  sufficientReserve: boolean;
+}
+
+export class TrustlineService {
+  async checkUsdcTrustline(publicKey: string): Promise<TrustlineCheckResult> {
+    try {
+      const server = new Horizon.Server(env.horizonUrl);
+      const account = await server.loadAccount(publicKey);
+
+      const hasLine = account.balances.some(
+        (balance) =>
+          'asset_code' in balance &&
+          balance.asset_code === 'USDC' &&
+          'asset_issuer' in balance &&
+          balance.asset_issuer === env.usdcIssuer
+      );
+
+      return {
+        hasLine,
+        // Reserve sizing (base reserve + subentry count) is a future concern — MVP
+        // assumes a trustline that exists has sufficient reserve backing it.
+        sufficientReserve: true,
+      };
+    } catch {
+      return { hasLine: false, sufficientReserve: false };
+    }
+  }
+}
+
+export const trustlineService = new TrustlineService();

--- a/src/features/wallet/services/__tests__/TrustlineService.test.ts
+++ b/src/features/wallet/services/__tests__/TrustlineService.test.ts
@@ -1,0 +1,62 @@
+import { TrustlineService } from '@/features/wallet/services/TrustlineService';
+
+const mockLoadAccount = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: mockLoadAccount,
+    })),
+  },
+}));
+
+// jest.setup.ts sets EXPO_PUBLIC_USDC_ISSUER to this value.
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MUGHC2XLYUUXV6ZLW75PN7CHLIW2NSIW74UZEST66';
+const PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVWXY';
+
+describe('TrustlineService', () => {
+  beforeEach(() => {
+    mockLoadAccount.mockReset();
+  });
+
+  it('returns hasLine: true when the account has a matching USDC trustline', async () => {
+    mockLoadAccount.mockResolvedValue({
+      balances: [
+        { asset_type: 'native', balance: '100' },
+        {
+          asset_type: 'credit_alphanum4',
+          asset_code: 'USDC',
+          asset_issuer: USDC_ISSUER,
+          balance: '50',
+        },
+      ],
+    });
+
+    const service = new TrustlineService();
+    const result = await service.checkUsdcTrustline(PUBLIC_KEY);
+
+    expect(result).toEqual({ hasLine: true, sufficientReserve: true });
+  });
+
+  it('returns hasLine: false when no USDC trustline entry exists', async () => {
+    mockLoadAccount.mockResolvedValue({
+      balances: [{ asset_type: 'native', balance: '100' }],
+    });
+
+    const service = new TrustlineService();
+    const result = await service.checkUsdcTrustline(PUBLIC_KEY);
+
+    // sufficientReserve is a static true for MVP (see TrustlineService) except
+    // when the account lookup itself fails — that's the "not found" case below.
+    expect(result).toEqual({ hasLine: false, sufficientReserve: true });
+  });
+
+  it('returns hasLine: false when the account cannot be found', async () => {
+    mockLoadAccount.mockRejectedValue(new Error('Not Found'));
+
+    const service = new TrustlineService();
+    const result = await service.checkUsdcTrustline(PUBLIC_KEY);
+
+    expect(result).toEqual({ hasLine: false, sufficientReserve: false });
+  });
+});


### PR DESCRIPTION
Closes #34

## Description
Implements the complete C12 receive payment flow across all 12 atomic tasks (CLI-061–CLI-072). Full receiver journey from amount entry through NFC broadcast, waiting, and success/failure outcomes, including USDC trustline gating, session timer coordination, analytics instrumentation, and architecture documentation.

## Atomic Tasks Delivered
- CLI-061: ReceiveHomeView — amount input, asset selector, validation gating
- CLI-062: receiveAmountSchema — Zod schema with USDC precision guard and localized errors
- CLI-063: PaymentRequestBuilder — wraps createPaymentRequest with 5-min expiry default
- CLI-064: ReceiveListeningView — NFC broadcast on mount, countdown, cancel
- CLI-065: useReceivePayment — FSM orchestrator (idle→preparing→broadcasting→waiting→success/failed/cancelled)
- CLI-066: WaitingForPaymentView — progress display with 60s timeout
- CLI-067: ReceiveSuccessView — summary and reset/home actions
- CLI-068: ReceiveFailedView — error-specific messages, retry and change-amount paths
- CLI-069: ReceiveSessionManager — safe timer coordination with cancelAll()
- CLI-070: TrustlineService — USDC trustline check via Horizon before listen
- CLI-071: Analytics events — RECEIVE_STARTED/BROADCAST/WAITING/COMPLETED/FAILED/CANCELLED with sanitized buckets
- CLI-072: docs/receive-flow.md — state diagram, file map, timeout model, error matrix, analytics mapping

## How Has This Been Tested?
- Unit tests: receiveAmountSchema, PaymentRequestBuilder, ReceiveSessionManager, TrustlineService
- FSM orchestrator tested with mocked NFC, trustline, session, and analytics
- All existing tests pass (69 total), typecheck, lint, and prettier checks green

## Checklist
- [x] My code follows the coding conventions of this project
- [x] I have added/updated tests if needed
- [x] I have updated documentation
- [x] My changes generate no new warnings or errors
