### PR TITLE
feat(wallet): implement C08 Stellar wallet accounts, balances and assets

### DIFF
--- a/src/app/(onboarding)/_layout.tsx
+++ b/src/app/(onboarding)/_layout.tsx
@@ -5,6 +5,7 @@ export default function OnboardingLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="welcome" />
       <Stack.Screen name="create-passkey" />
+      <Stack.Screen name="wallet-setup" />
       <Stack.Screen name="locked" />
     </Stack>
   );

--- a/src/app/(onboarding)/wallet-setup.tsx
+++ b/src/app/(onboarding)/wallet-setup.tsx
@@ -1,0 +1,5 @@
+import { WalletSetupView } from '@/features/wallet/views/WalletSetupView';
+
+export default function WalletSetupScreen() {
+  return <WalletSetupView />;
+}

--- a/src/features/auth/views/CreatePasskeyView.tsx
+++ b/src/features/auth/views/CreatePasskeyView.tsx
@@ -37,9 +37,8 @@ export function CreatePasskeyView() {
 
     if (success) {
       setViewState('success');
-      // Navigate to main app after brief success feedback
       setTimeout(() => {
-        router.replace('/(tabs)/receive');
+        router.replace('/(onboarding)/wallet-setup');
       }, 1200);
     } else {
       setErrorMessage(

--- a/src/features/receive/views/ReceiveHomeView.tsx
+++ b/src/features/receive/views/ReceiveHomeView.tsx
@@ -1,11 +1,16 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
 
 import { ThemedText } from '@/components/themed-text';
 import { Screen } from '@/components/ui';
 import { AnalyticsEvents } from '@/constants/analytics-events';
 import { trackEvent } from '@/lib/analytics';
+import { AssetSelector } from '@/features/wallet/components/AssetSelector';
+import type { SupportedAssetCode } from '@/features/wallet/constants/assets';
 
 export const ReceiveHomeView = () => {
+  const [asset, setAsset] = useState<SupportedAssetCode>('XLM');
+
   useEffect(() => {
     trackEvent(AnalyticsEvents.RECEIVE_OPENED);
   }, []);
@@ -14,6 +19,13 @@ export const ReceiveHomeView = () => {
     <Screen>
       <ThemedText type="subtitle">Receive</ThemedText>
       <ThemedText themeColor="textSecondary">Accept contactless payment requests here.</ThemedText>
+      <AssetSelector value={asset} onChange={setAsset} style={styles.selector} />
     </Screen>
   );
 };
+
+const styles = StyleSheet.create({
+  selector: {
+    marginTop: 16,
+  },
+});

--- a/src/features/send/views/SendHomeView.tsx
+++ b/src/features/send/views/SendHomeView.tsx
@@ -1,9 +1,25 @@
+import { useState } from 'react';
+import { StyleSheet } from 'react-native';
+
 import { ThemedText } from '@/components/themed-text';
 import { Screen } from '@/components/ui';
+import { AssetSelector } from '@/features/wallet/components/AssetSelector';
+import type { SupportedAssetCode } from '@/features/wallet/constants/assets';
 
-export const SendHomeView = () => (
-  <Screen>
-    <ThemedText type="subtitle">Send</ThemedText>
-    <ThemedText themeColor="textSecondary">Send payments to contacts and merchants.</ThemedText>
-  </Screen>
-);
+export const SendHomeView = () => {
+  const [asset, setAsset] = useState<SupportedAssetCode>('XLM');
+
+  return (
+    <Screen>
+      <ThemedText type="subtitle">Send</ThemedText>
+      <ThemedText themeColor="textSecondary">Send payments to contacts and merchants.</ThemedText>
+      <AssetSelector value={asset} onChange={setAsset} style={styles.selector} />
+    </Screen>
+  );
+};
+
+const styles = StyleSheet.create({
+  selector: {
+    marginTop: 16,
+  },
+});

--- a/src/features/wallet/components/AssetSelector.tsx
+++ b/src/features/wallet/components/AssetSelector.tsx
@@ -1,0 +1,71 @@
+import { Pressable, StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { ThemedText } from '@/components/themed-text';
+import { Spacing } from '@/constants/theme';
+import { useTheme } from '@/hooks/use-theme';
+import {
+  STELLAR_ASSETS,
+  SUPPORTED_ASSET_CODES,
+  type SupportedAssetCode,
+} from '@/features/wallet/constants/assets';
+
+const MIN_TOUCH_TARGET = 44;
+
+export interface AssetSelectorProps {
+  value: SupportedAssetCode;
+  onChange: (code: SupportedAssetCode) => void;
+  options?: readonly SupportedAssetCode[];
+  style?: StyleProp<ViewStyle>;
+}
+
+export function AssetSelector({
+  value,
+  onChange,
+  options = SUPPORTED_ASSET_CODES,
+  style,
+}: AssetSelectorProps) {
+  const theme = useTheme();
+
+  return (
+    <View
+      accessibilityRole="tablist"
+      style={[styles.container, { backgroundColor: theme.backgroundElement }, style]}
+    >
+      {options.map((code) => {
+        const asset = STELLAR_ASSETS[code];
+        const selected = code === value;
+
+        return (
+          <Pressable
+            key={code}
+            onPress={() => onChange(code)}
+            accessibilityRole="tab"
+            accessibilityState={{ selected }}
+            accessibilityLabel={asset.displayName}
+            style={[styles.option, selected && { backgroundColor: theme.background }]}
+          >
+            <ThemedText type="smallBold" style={selected ? { color: theme.primary } : undefined}>
+              {asset.code}
+            </ThemedText>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    borderRadius: Spacing.three,
+    padding: Spacing.half,
+    gap: Spacing.half,
+  },
+  option: {
+    flex: 1,
+    minHeight: MIN_TOUCH_TARGET,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: Spacing.two,
+  },
+});

--- a/src/features/wallet/hooks/useWallet.test.ts
+++ b/src/features/wallet/hooks/useWallet.test.ts
@@ -1,0 +1,143 @@
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import { AccountService } from '@/features/wallet/services/AccountService';
+import { fetchBalances } from '@/features/wallet/services/BalanceService';
+import { ensureUsdcTrustline } from '@/features/wallet/services/TrustlineService';
+import { useWalletStore } from '@/features/wallet/state/walletStore';
+import { useWallet, type UseWalletResult } from './useWallet';
+
+jest.mock('@/features/wallet/services/AccountService', () => ({
+  AccountService: {
+    getOrCreateKeypair: jest.fn(),
+    accountExistsOnNetwork: jest.fn(),
+    fundTestnetAccount: jest.fn(),
+  },
+}));
+
+jest.mock('@/features/wallet/services/BalanceService', () => ({
+  fetchBalances: jest.fn(),
+}));
+
+jest.mock('@/features/wallet/services/TrustlineService', () => ({
+  ensureUsdcTrustline: jest.fn(),
+}));
+
+jest.mock('@/lib/SecureKeyStore', () => ({
+  SecureKeyStore: {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const mockGetOrCreateKeypair = AccountService.getOrCreateKeypair as jest.Mock;
+const mockAccountExistsOnNetwork = AccountService.accountExistsOnNetwork as jest.Mock;
+const mockFundTestnetAccount = AccountService.fundTestnetAccount as jest.Mock;
+const mockFetchBalances = fetchBalances as jest.Mock;
+const mockEnsureUsdcTrustline = ensureUsdcTrustline as jest.Mock;
+const mockSecureGet = SecureKeyStore.get as jest.Mock;
+
+async function renderUseWallet() {
+  const captured: { value?: UseWalletResult } = {};
+
+  function TestComponent() {
+    captured.value = useWallet();
+    return null;
+  }
+
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(React.createElement(TestComponent));
+  });
+
+  return {
+    get result(): UseWalletResult {
+      return captured.value!;
+    },
+    unmount: () => act(() => renderer.unmount()),
+  };
+}
+
+describe('useWallet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSecureGet.mockResolvedValue(null);
+    useWalletStore.getState().reset();
+  });
+
+  it('creates and funds a testnet wallet end to end', async () => {
+    mockGetOrCreateKeypair.mockResolvedValue({ publicKey: 'GPUB', isNew: true });
+    mockFundTestnetAccount.mockResolvedValue({ outcome: 'funded' });
+    mockEnsureUsdcTrustline.mockResolvedValue({ status: 'created' });
+    mockFetchBalances.mockResolvedValue({ xlm: '10000', usdc: '0', hasUsdcTrustline: true });
+
+    const hook = await renderUseWallet();
+
+    await act(async () => {
+      await hook.result.createWallet();
+    });
+
+    expect(hook.result.status).toBe('ready');
+    expect(hook.result.publicKey).toBe('GPUB');
+    expect(hook.result.balances).toEqual({ xlm: '10000', usdc: '0', hasUsdcTrustline: true });
+    expect(hook.result.isReady).toBe(true);
+
+    hook.unmount();
+  });
+
+  it('surfaces a funding error without reaching ready', async () => {
+    mockGetOrCreateKeypair.mockResolvedValue({ publicKey: 'GPUB', isNew: true });
+    mockFundTestnetAccount.mockResolvedValue({ outcome: 'error', message: 'friendbot down' });
+
+    const hook = await renderUseWallet();
+
+    await act(async () => {
+      await hook.result.createWallet();
+    });
+
+    expect(hook.result.status).toBe('error');
+    expect(hook.result.error).toBe('friendbot down');
+    expect(mockFetchBalances).not.toHaveBeenCalled();
+
+    hook.unmount();
+  });
+
+  it('does nothing when checkFunding is called with no known public key', async () => {
+    const hook = await renderUseWallet();
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await hook.result.checkFunding();
+    });
+
+    expect(outcome).toBe(false);
+    expect(mockAccountExistsOnNetwork).not.toHaveBeenCalled();
+    expect(hook.result.status).toBe('idle');
+
+    hook.unmount();
+  });
+
+  it('completes setup once checkFunding detects the account is funded', async () => {
+    useWalletStore.getState().setPublicKey('GPUB');
+    useWalletStore.getState().setStatus('awaiting_funding');
+
+    mockAccountExistsOnNetwork.mockResolvedValue(true);
+    mockEnsureUsdcTrustline.mockResolvedValue({ status: 'already_trusted' });
+    mockFetchBalances.mockResolvedValue({ xlm: '5', usdc: null, hasUsdcTrustline: false });
+
+    const hook = await renderUseWallet();
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await hook.result.checkFunding();
+    });
+
+    expect(outcome).toBe(true);
+    expect(hook.result.status).toBe('ready');
+    expect(hook.result.balances).toEqual({ xlm: '5', usdc: null, hasUsdcTrustline: false });
+
+    hook.unmount();
+  });
+});

--- a/src/features/wallet/hooks/useWallet.ts
+++ b/src/features/wallet/hooks/useWallet.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { env } from '@/lib/env';
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import { SECURE_KEYS } from '@/lib/SecureKeyStore.types';
+import { AccountService } from '@/features/wallet/services/AccountService';
+import { fetchBalances, type WalletBalances } from '@/features/wallet/services/BalanceService';
+import { ensureUsdcTrustline } from '@/features/wallet/services/TrustlineService';
+import { useWalletStore, type WalletStatus } from '@/features/wallet/state/walletStore';
+
+export interface UseWalletResult {
+  status: WalletStatus;
+  publicKey: string | null;
+  balances: WalletBalances | null;
+  error: string | null;
+  isReady: boolean;
+  createWallet: () => Promise<boolean>;
+  checkFunding: () => Promise<boolean>;
+  refreshBalances: () => Promise<void>;
+}
+
+async function finishSetup(publicKey: string): Promise<void> {
+  const { setBalances, setStatus, setError } = useWalletStore.getState();
+
+  const trustlineResult = await ensureUsdcTrustline(publicKey).catch(() => null);
+  if (
+    trustlineResult &&
+    trustlineResult.status !== 'already_trusted' &&
+    trustlineResult.status !== 'created'
+  ) {
+    setError(trustlineResult.message ?? null);
+  }
+
+  const balances = await fetchBalances(publicKey);
+  setBalances(balances);
+  setStatus('ready');
+}
+
+export function useWallet(): UseWalletResult {
+  const status = useWalletStore((state) => state.status);
+  const publicKey = useWalletStore((state) => state.publicKey);
+  const balances = useWalletStore((state) => state.balances);
+  const error = useWalletStore((state) => state.error);
+  const hasHydrated = useWalletStore((state) => state.hasHydrated);
+
+  const hydrating = useRef(false);
+
+  useEffect(() => {
+    if (hasHydrated || hydrating.current) return;
+    hydrating.current = true;
+
+    SecureKeyStore.get(SECURE_KEYS.WALLET_STELLAR_PUBLIC_KEY)
+      .then((storedPublicKey) => {
+        const { setPublicKey, setStatus, setHydrated } = useWalletStore.getState();
+        setHydrated();
+
+        if (storedPublicKey) {
+          setPublicKey(storedPublicKey);
+          setStatus('ready');
+        }
+      })
+      .catch(() => {
+        useWalletStore.getState().setHydrated();
+      });
+  }, [hasHydrated]);
+
+  const refreshBalances = useCallback(async () => {
+    const currentPublicKey = useWalletStore.getState().publicKey;
+    if (!currentPublicKey) return;
+
+    try {
+      const next = await fetchBalances(currentPublicKey);
+      useWalletStore.getState().setBalances(next);
+    } catch {
+      useWalletStore
+        .getState()
+        .setError('No se pudieron actualizar los saldos. Verifica tu conexión.');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status === 'ready' && publicKey && !balances) {
+      void refreshBalances();
+    }
+  }, [status, publicKey, balances, refreshBalances]);
+
+  const createWallet = useCallback(async (): Promise<boolean> => {
+    const { setStatus, setPublicKey, setError } = useWalletStore.getState();
+    setStatus('creating');
+    setError(null);
+
+    try {
+      const { publicKey: newPublicKey } = await AccountService.getOrCreateKeypair();
+      setPublicKey(newPublicKey);
+
+      if (env.stellarNetwork === 'testnet') {
+        const fundingResult = await AccountService.fundTestnetAccount(newPublicKey);
+        if (fundingResult.outcome === 'error') {
+          setStatus('error');
+          setError(fundingResult.message ?? null);
+          return false;
+        }
+      } else {
+        const exists = await AccountService.accountExistsOnNetwork(newPublicKey);
+        if (!exists) {
+          setStatus('awaiting_funding');
+          return false;
+        }
+      }
+
+      await finishSetup(newPublicKey);
+      return true;
+    } catch {
+      setStatus('error');
+      setError('No se pudo crear la billetera. Inténtalo de nuevo.');
+      return false;
+    }
+  }, []);
+
+  const checkFunding = useCallback(async (): Promise<boolean> => {
+    const currentPublicKey = useWalletStore.getState().publicKey;
+    if (!currentPublicKey) return false;
+
+    try {
+      const exists = await AccountService.accountExistsOnNetwork(currentPublicKey);
+      if (!exists) return false;
+
+      await finishSetup(currentPublicKey);
+      return true;
+    } catch {
+      useWalletStore
+        .getState()
+        .setError('No se pudo verificar el estado de la cuenta. Inténtalo de nuevo.');
+      return false;
+    }
+  }, []);
+
+  return {
+    status,
+    publicKey,
+    balances,
+    error,
+    isReady: status === 'ready',
+    createWallet,
+    checkFunding,
+    refreshBalances,
+  };
+}

--- a/src/features/wallet/services/AccountService.test.ts
+++ b/src/features/wallet/services/AccountService.test.ts
@@ -1,0 +1,146 @@
+import { Horizon, NotFoundError } from '@stellar/stellar-sdk';
+
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import { env } from '@/lib/env';
+import { AccountService } from './AccountService';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  class NotFoundError extends Error {}
+
+  const friendbotCall = jest.fn();
+  const horizonServerInstance = {
+    loadAccount: jest.fn(),
+    friendbot: jest.fn(() => ({ call: friendbotCall })),
+  };
+
+  return {
+    Horizon: {
+      Server: jest.fn(() => horizonServerInstance),
+    },
+    Keypair: {
+      random: jest.fn().mockReturnValue({
+        publicKey: () => 'GFAKEPUBLICKEY0000000000000000000000000000000000000000',
+        secret: () => 'SFAKESECRETKEY00000000000000000000000000000000000000000',
+      }),
+    },
+    NotFoundError,
+    Networks: {
+      PUBLIC: 'Public Global Stellar Network ; September 2015',
+      TESTNET: 'Test SDF Network ; September 2015',
+    },
+  };
+});
+
+jest.mock('@/lib/SecureKeyStore', () => ({
+  SecureKeyStore: {
+    get: jest.fn(),
+    set: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org') as unknown as {
+  loadAccount: jest.Mock;
+  friendbot: (address: string) => { call: jest.Mock };
+};
+const friendbotCall = server.friendbot('GPUB').call;
+
+describe('AccountService.getOrCreateKeypair', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the existing public key without generating a new one', async () => {
+    (SecureKeyStore.get as jest.Mock).mockResolvedValueOnce('GEXISTINGPUBLICKEY');
+
+    const result = await AccountService.getOrCreateKeypair();
+
+    expect(result).toEqual({ publicKey: 'GEXISTINGPUBLICKEY', isNew: false });
+    expect(SecureKeyStore.set).not.toHaveBeenCalled();
+  });
+
+  it('generates and persists a new keypair when none exists', async () => {
+    (SecureKeyStore.get as jest.Mock).mockResolvedValueOnce(null);
+
+    const result = await AccountService.getOrCreateKeypair();
+
+    expect(result.isNew).toBe(true);
+    expect(SecureKeyStore.set).toHaveBeenCalledWith(
+      'ding.wallet.stellar.secretKey',
+      expect.any(String)
+    );
+    expect(SecureKeyStore.set).toHaveBeenCalledWith(
+      'ding.wallet.stellar.publicKey',
+      expect.any(String)
+    );
+  });
+});
+
+describe('AccountService.accountExistsOnNetwork', () => {
+  beforeEach(() => {
+    server.loadAccount.mockReset();
+  });
+
+  it('returns true when the account loads successfully', async () => {
+    server.loadAccount.mockResolvedValueOnce({});
+    await expect(AccountService.accountExistsOnNetwork('GPUB')).resolves.toBe(true);
+  });
+
+  it('returns false when the account is not found', async () => {
+    server.loadAccount.mockRejectedValueOnce(new NotFoundError('not found', {}));
+    await expect(AccountService.accountExistsOnNetwork('GPUB')).resolves.toBe(false);
+  });
+
+  it('rethrows unexpected errors', async () => {
+    server.loadAccount.mockRejectedValueOnce(new Error('network down'));
+    await expect(AccountService.accountExistsOnNetwork('GPUB')).rejects.toThrow('network down');
+  });
+});
+
+describe('AccountService.fundTestnetAccount', () => {
+  const originalNetwork = env.stellarNetwork;
+
+  beforeEach(() => {
+    friendbotCall.mockReset();
+    (env as { stellarNetwork: string }).stellarNetwork = 'testnet';
+  });
+
+  afterAll(() => {
+    (env as { stellarNetwork: string }).stellarNetwork = originalNetwork;
+  });
+
+  it('funds a fresh account successfully', async () => {
+    friendbotCall.mockResolvedValueOnce({});
+    const result = await AccountService.fundTestnetAccount('GPUB');
+    expect(result).toEqual({ outcome: 'funded' });
+  });
+
+  it('treats an already-funded account as a non-error outcome', async () => {
+    const error = Object.assign(new Error('Bad Request'), {
+      response: { data: { detail: 'createAccountAlreadyExist(GPUB)' } },
+    });
+    friendbotCall.mockRejectedValueOnce(error);
+
+    const result = await AccountService.fundTestnetAccount('GPUB');
+
+    expect(result).toEqual({ outcome: 'already_funded' });
+  });
+
+  it('surfaces a user-safe error on a genuine funding failure', async () => {
+    friendbotCall.mockRejectedValueOnce(new Error('network down'));
+
+    const result = await AccountService.fundTestnetAccount('GPUB');
+
+    expect(result.outcome).toBe('error');
+    expect(result.message).toBeTruthy();
+  });
+
+  it('refuses to fund on mainnet', async () => {
+    (env as { stellarNetwork: string }).stellarNetwork = 'mainnet';
+
+    const result = await AccountService.fundTestnetAccount('GPUB');
+
+    expect(result.outcome).toBe('error');
+    expect(friendbotCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/wallet/services/AccountService.ts
+++ b/src/features/wallet/services/AccountService.ts
@@ -1,0 +1,88 @@
+import { Horizon, Keypair, NotFoundError } from '@stellar/stellar-sdk';
+
+import { env } from '@/lib/env';
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import { SECURE_KEYS } from '@/lib/SecureKeyStore.types';
+import { ensureStellarPolyfills } from './stellarPolyfills';
+
+ensureStellarPolyfills();
+
+const server = new Horizon.Server(env.horizonUrl);
+
+export interface WalletKeypair {
+  publicKey: string;
+  isNew: boolean;
+}
+
+export type FundingOutcome = 'funded' | 'already_funded' | 'error';
+
+export interface FundingResult {
+  outcome: FundingOutcome;
+  message?: string;
+}
+
+function isAccountAlreadyFundedError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const data = (error as { response?: { data?: Record<string, unknown> } }).response?.data;
+  if (!data) return false;
+
+  const detail = typeof data.detail === 'string' ? data.detail : '';
+  const operations = (data.extras as { result_codes?: { operations?: string[] } } | undefined)
+    ?.result_codes?.operations;
+
+  return (
+    detail.includes('createAccountAlreadyExist') ||
+    Boolean(operations?.includes('op_already_exists'))
+  );
+}
+
+export const AccountService = {
+  async getOrCreateKeypair(): Promise<WalletKeypair> {
+    const existingPublicKey = await SecureKeyStore.get(SECURE_KEYS.WALLET_STELLAR_PUBLIC_KEY);
+    if (existingPublicKey) {
+      return { publicKey: existingPublicKey, isNew: false };
+    }
+
+    const keypair = Keypair.random();
+    await SecureKeyStore.set(SECURE_KEYS.WALLET_STELLAR_SECRET_KEY, keypair.secret());
+    await SecureKeyStore.set(SECURE_KEYS.WALLET_STELLAR_PUBLIC_KEY, keypair.publicKey());
+
+    return { publicKey: keypair.publicKey(), isNew: true };
+  },
+
+  async accountExistsOnNetwork(publicKey: string): Promise<boolean> {
+    try {
+      await server.loadAccount(publicKey);
+      return true;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return false;
+      }
+      throw error;
+    }
+  },
+
+  async fundTestnetAccount(publicKey: string): Promise<FundingResult> {
+    if (env.stellarNetwork !== 'testnet') {
+      return {
+        outcome: 'error',
+        message: 'La financiación automática solo está disponible en testnet.',
+      };
+    }
+
+    try {
+      await server.friendbot(publicKey).call();
+      return { outcome: 'funded' };
+    } catch (error) {
+      if (isAccountAlreadyFundedError(error)) {
+        return { outcome: 'already_funded' };
+      }
+
+      return {
+        outcome: 'error',
+        message: 'No se pudo financiar la cuenta de prueba en testnet. Inténtalo de nuevo.',
+      };
+    }
+  },
+};

--- a/src/features/wallet/services/BalanceService.test.ts
+++ b/src/features/wallet/services/BalanceService.test.ts
@@ -1,0 +1,91 @@
+import { Horizon } from '@stellar/stellar-sdk';
+
+import { fetchBalances, parseBalances } from './BalanceService';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const horizonServerInstance = {
+    loadAccount: jest.fn(),
+  };
+
+  return {
+    Horizon: {
+      Server: jest.fn(() => horizonServerInstance),
+    },
+    Networks: {
+      PUBLIC: 'Public Global Stellar Network ; September 2015',
+      TESTNET: 'Test SDF Network ; September 2015',
+    },
+  };
+});
+
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MUGHC2XLYUUXV6ZLW75PN7CHLIW2NSIW74UZEST66';
+const server = new Horizon.Server('https://horizon-testnet.stellar.org') as unknown as {
+  loadAccount: jest.Mock;
+};
+
+describe('parseBalances', () => {
+  it('extracts the native XLM balance', () => {
+    const result = parseBalances({
+      balances: [{ asset_type: 'native', balance: '123.4567890' } as never],
+    });
+
+    expect(result.xlm).toBe('123.4567890');
+    expect(result.usdc).toBeNull();
+    expect(result.hasUsdcTrustline).toBe(false);
+  });
+
+  it('extracts the USDC balance when it matches the configured issuer', () => {
+    const result = parseBalances({
+      balances: [
+        { asset_type: 'native', balance: '50.0000000' } as never,
+        {
+          asset_type: 'credit_alphanum4',
+          asset_code: 'USDC',
+          asset_issuer: USDC_ISSUER,
+          balance: '10.0000000',
+        } as never,
+      ],
+    });
+
+    expect(result.usdc).toBe('10.0000000');
+    expect(result.hasUsdcTrustline).toBe(true);
+  });
+
+  it('ignores credit lines from an issuer other than the configured USDC issuer', () => {
+    const result = parseBalances({
+      balances: [
+        {
+          asset_type: 'credit_alphanum4',
+          asset_code: 'USDC',
+          asset_issuer: 'GDIFFERENTISSUERXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+          balance: '5.0000000',
+        } as never,
+      ],
+    });
+
+    expect(result.usdc).toBeNull();
+    expect(result.hasUsdcTrustline).toBe(false);
+  });
+
+  it('defaults the XLM balance to 0 when no native line is present', () => {
+    const result = parseBalances({ balances: [] });
+    expect(result.xlm).toBe('0');
+  });
+});
+
+describe('fetchBalances', () => {
+  beforeEach(() => {
+    server.loadAccount.mockReset();
+  });
+
+  it('loads the account from Horizon and parses its balances', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'native', balance: '5.0000000' }],
+    });
+
+    const result = await fetchBalances('GPUBLICKEY');
+
+    expect(server.loadAccount).toHaveBeenCalledWith('GPUBLICKEY');
+    expect(result.xlm).toBe('5.0000000');
+  });
+});

--- a/src/features/wallet/services/BalanceService.ts
+++ b/src/features/wallet/services/BalanceService.ts
@@ -1,0 +1,51 @@
+import { Horizon } from '@stellar/stellar-sdk';
+
+import { env } from '@/lib/env';
+import { STELLAR_ASSETS } from '@/features/wallet/constants/assets';
+import { ensureStellarPolyfills } from './stellarPolyfills';
+
+ensureStellarPolyfills();
+
+const server = new Horizon.Server(env.horizonUrl);
+
+export interface WalletBalances {
+  xlm: string;
+  usdc: string | null;
+  hasUsdcTrustline: boolean;
+}
+
+type AccountBalances = Pick<Horizon.AccountResponse, 'balances'>;
+
+export function parseBalances(account: AccountBalances): WalletBalances {
+  let xlm = '0';
+  let usdc: string | null = null;
+  let hasUsdcTrustline = false;
+
+  for (const line of account.balances) {
+    if (line.asset_type === 'native') {
+      xlm = line.balance;
+      continue;
+    }
+
+    if (
+      'asset_code' in line &&
+      line.asset_code === STELLAR_ASSETS.USDC.code &&
+      line.asset_issuer === STELLAR_ASSETS.USDC.issuer
+    ) {
+      usdc = line.balance;
+      hasUsdcTrustline = true;
+    }
+  }
+
+  return { xlm, usdc, hasUsdcTrustline };
+}
+
+export async function fetchBalances(publicKey: string): Promise<WalletBalances> {
+  const account = await server.loadAccount(publicKey);
+  return parseBalances(account);
+}
+
+export const BalanceService = {
+  parseBalances,
+  fetchBalances,
+};

--- a/src/features/wallet/services/TrustlineService.test.ts
+++ b/src/features/wallet/services/TrustlineService.test.ts
@@ -1,0 +1,179 @@
+import { Horizon, TransactionBuilder } from '@stellar/stellar-sdk';
+
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import {
+  ensureUsdcTrustline,
+  hasSufficientReserveForTrustline,
+  hasUsdcTrustline,
+} from './TrustlineService';
+
+jest.mock('@stellar/stellar-sdk', () => {
+  class MockAsset {
+    code: string;
+    issuer?: string;
+    constructor(code: string, issuer?: string) {
+      this.code = code;
+      this.issuer = issuer;
+    }
+  }
+
+  const horizonServerInstance = {
+    loadAccount: jest.fn(),
+    submitTransaction: jest.fn(),
+  };
+
+  const transactionInstance = { sign: jest.fn() };
+
+  class MockTransactionBuilder {
+    addOperation() {
+      return this;
+    }
+    setTimeout() {
+      return this;
+    }
+    build() {
+      return transactionInstance;
+    }
+  }
+
+  return {
+    Horizon: {
+      Server: jest.fn(() => horizonServerInstance),
+    },
+    Asset: MockAsset,
+    BASE_FEE: '100',
+    Keypair: {
+      fromSecret: jest.fn().mockReturnValue({ publicKey: () => 'GFAKEPUBLICKEY' }),
+    },
+    Operation: {
+      changeTrust: jest.fn().mockReturnValue({}),
+    },
+    TransactionBuilder: MockTransactionBuilder,
+    Networks: {
+      PUBLIC: 'Public Global Stellar Network ; September 2015',
+      TESTNET: 'Test SDF Network ; September 2015',
+    },
+  };
+});
+
+jest.mock('@/lib/SecureKeyStore', () => ({
+  SecureKeyStore: {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+const USDC_ISSUER = 'GBBD47IF6LWK7P7MUGHC2XLYUUXV6ZLW75PN7CHLIW2NSIW74UZEST66';
+
+const server = new Horizon.Server('https://horizon-testnet.stellar.org') as unknown as {
+  loadAccount: jest.Mock;
+  submitTransaction: jest.Mock;
+};
+const transaction = new TransactionBuilder({} as never).build() as unknown as { sign: jest.Mock };
+
+describe('hasUsdcTrustline', () => {
+  it('returns true when a matching USDC trustline exists', () => {
+    const result = hasUsdcTrustline({
+      balances: [
+        { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: USDC_ISSUER } as never,
+      ],
+    });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no USDC trustline is present', () => {
+    const result = hasUsdcTrustline({ balances: [{ asset_type: 'native' } as never] });
+    expect(result).toBe(false);
+  });
+});
+
+describe('hasSufficientReserveForTrustline', () => {
+  it('allows a trustline when the balance comfortably covers the new reserve', () => {
+    expect(hasSufficientReserveForTrustline(10, 0)).toBe(true);
+  });
+
+  it('rejects a trustline when the balance sits at the base reserve floor', () => {
+    expect(hasSufficientReserveForTrustline(1, 0)).toBe(false);
+  });
+
+  it('accounts for existing subentries when computing the required reserve', () => {
+    expect(hasSufficientReserveForTrustline(3.005, 3)).toBe(false);
+    expect(hasSufficientReserveForTrustline(3.02, 3)).toBe(true);
+  });
+});
+
+describe('ensureUsdcTrustline', () => {
+  beforeEach(() => {
+    server.loadAccount.mockReset();
+    server.submitTransaction.mockReset();
+    transaction.sign.mockReset();
+    (SecureKeyStore.get as jest.Mock).mockReset();
+  });
+
+  it('is idempotent when a trustline already exists', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: USDC_ISSUER }],
+      subentry_count: 1,
+    });
+
+    const result = await ensureUsdcTrustline('GPUB');
+
+    expect(result).toEqual({ status: 'already_trusted' });
+    expect(server.submitTransaction).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a user-safe error when the reserve is insufficient, without touching the secret key', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'native', balance: '1.0000000' }],
+      subentry_count: 0,
+    });
+
+    const result = await ensureUsdcTrustline('GPUB');
+
+    expect(result.status).toBe('insufficient_reserve');
+    expect(result.message).toBeTruthy();
+    expect(SecureKeyStore.get).not.toHaveBeenCalled();
+  });
+
+  it('creates the trustline when funds are sufficient', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'native', balance: '10.0000000' }],
+      subentry_count: 0,
+    });
+    (SecureKeyStore.get as jest.Mock).mockResolvedValueOnce('SFAKESECRET');
+    server.submitTransaction.mockResolvedValueOnce({});
+
+    const result = await ensureUsdcTrustline('GPUB');
+
+    expect(result).toEqual({ status: 'created' });
+    expect(transaction.sign).toHaveBeenCalled();
+    expect(server.submitTransaction).toHaveBeenCalled();
+  });
+
+  it('returns a user-safe error when no secret key is stored on this device', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'native', balance: '10.0000000' }],
+      subentry_count: 0,
+    });
+    (SecureKeyStore.get as jest.Mock).mockResolvedValueOnce(null);
+
+    const result = await ensureUsdcTrustline('GPUB');
+
+    expect(result.status).toBe('error');
+    expect(server.submitTransaction).not.toHaveBeenCalled();
+  });
+
+  it('returns a user-safe error when submission fails', async () => {
+    server.loadAccount.mockResolvedValueOnce({
+      balances: [{ asset_type: 'native', balance: '10.0000000' }],
+      subentry_count: 0,
+    });
+    (SecureKeyStore.get as jest.Mock).mockResolvedValueOnce('SFAKESECRET');
+    server.submitTransaction.mockRejectedValueOnce(new Error('tx_failed'));
+
+    const result = await ensureUsdcTrustline('GPUB');
+
+    expect(result.status).toBe('error');
+  });
+});

--- a/src/features/wallet/services/TrustlineService.ts
+++ b/src/features/wallet/services/TrustlineService.ts
@@ -1,0 +1,106 @@
+import {
+  Asset,
+  BASE_FEE,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+
+import { env } from '@/lib/env';
+import { SecureKeyStore } from '@/lib/SecureKeyStore';
+import { SECURE_KEYS } from '@/lib/SecureKeyStore.types';
+import { STELLAR_ASSETS } from '@/features/wallet/constants/assets';
+import { ensureStellarPolyfills } from './stellarPolyfills';
+
+ensureStellarPolyfills();
+
+const server = new Horizon.Server(env.horizonUrl);
+
+const BASE_RESERVE_XLM = 0.5;
+const FEE_BUFFER_XLM = 0.01;
+
+export type TrustlineStatus = 'already_trusted' | 'created' | 'insufficient_reserve' | 'error';
+
+export interface TrustlineResult {
+  status: TrustlineStatus;
+  message?: string;
+}
+
+type TrustlineAccount = Pick<Horizon.AccountResponse, 'balances'>;
+
+export function hasUsdcTrustline(account: TrustlineAccount): boolean {
+  return account.balances.some(
+    (line) =>
+      'asset_code' in line &&
+      line.asset_code === STELLAR_ASSETS.USDC.code &&
+      line.asset_issuer === STELLAR_ASSETS.USDC.issuer
+  );
+}
+
+export function hasSufficientReserveForTrustline(
+  xlmBalance: number,
+  subentryCount: number
+): boolean {
+  const requiredMinBalance = (2 + subentryCount + 1) * BASE_RESERVE_XLM;
+  return xlmBalance >= requiredMinBalance + FEE_BUFFER_XLM;
+}
+
+function usdcSdkAsset(): Asset {
+  return new Asset(STELLAR_ASSETS.USDC.code, STELLAR_ASSETS.USDC.issuer);
+}
+
+export async function ensureUsdcTrustline(publicKey: string): Promise<TrustlineResult> {
+  const account = await server.loadAccount(publicKey);
+
+  if (hasUsdcTrustline(account)) {
+    return { status: 'already_trusted' };
+  }
+
+  const nativeBalance = account.balances.find((line) => line.asset_type === 'native');
+  const xlmBalance = nativeBalance ? Number(nativeBalance.balance) : 0;
+
+  if (!hasSufficientReserveForTrustline(xlmBalance, account.subentry_count)) {
+    return {
+      status: 'insufficient_reserve',
+      message:
+        'No hay suficiente saldo en XLM para habilitar USDC. Agrega fondos e inténtalo de nuevo.',
+    };
+  }
+
+  const secretKey = await SecureKeyStore.get(SECURE_KEYS.WALLET_STELLAR_SECRET_KEY);
+  if (!secretKey) {
+    return {
+      status: 'error',
+      message: 'No se encontró la llave de la billetera en este dispositivo.',
+    };
+  }
+
+  const keypair = Keypair.fromSecret(secretKey);
+
+  const transaction = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: env.networkPassphrase,
+  })
+    .addOperation(Operation.changeTrust({ asset: usdcSdkAsset() }))
+    .setTimeout(30)
+    .build();
+
+  transaction.sign(keypair);
+
+  try {
+    await server.submitTransaction(transaction);
+    return { status: 'created' };
+  } catch {
+    return {
+      status: 'error',
+      message: 'No se pudo habilitar USDC en este momento. Inténtalo de nuevo más tarde.',
+    };
+  }
+}
+
+export const TrustlineService = {
+  hasUsdcTrustline,
+  hasSufficientReserveForTrustline,
+  ensureUsdcTrustline,
+};

--- a/src/features/wallet/services/stellarPolyfills.ts
+++ b/src/features/wallet/services/stellarPolyfills.ts
@@ -1,0 +1,18 @@
+import { Buffer } from 'buffer';
+import process from 'process';
+import 'react-native-get-random-values';
+
+let applied = false;
+
+export function ensureStellarPolyfills(): void {
+  if (applied) return;
+
+  const globalScope = globalThis as typeof globalThis & {
+    Buffer?: typeof Buffer;
+    process?: typeof process;
+  };
+
+  globalScope.Buffer = globalScope.Buffer ?? Buffer;
+  globalScope.process = globalScope.process ?? process;
+  applied = true;
+}

--- a/src/features/wallet/state/walletStore.test.ts
+++ b/src/features/wallet/state/walletStore.test.ts
@@ -1,0 +1,62 @@
+import { useWalletStore } from './walletStore';
+
+describe('walletStore', () => {
+  beforeEach(() => {
+    useWalletStore.getState().reset();
+  });
+
+  it('starts idle with no wallet data', () => {
+    const state = useWalletStore.getState();
+    expect(state.status).toBe('idle');
+    expect(state.publicKey).toBeNull();
+    expect(state.balances).toBeNull();
+    expect(state.error).toBeNull();
+    expect(state.hasHydrated).toBe(false);
+  });
+
+  it('setPublicKey stores the public key', () => {
+    useWalletStore.getState().setPublicKey('GPUB');
+    expect(useWalletStore.getState().publicKey).toBe('GPUB');
+  });
+
+  it('setStatus transitions the status', () => {
+    useWalletStore.getState().setStatus('creating');
+    expect(useWalletStore.getState().status).toBe('creating');
+  });
+
+  it('setBalances stores the balances object', () => {
+    const balances = { xlm: '10', usdc: '5', hasUsdcTrustline: true };
+    useWalletStore.getState().setBalances(balances);
+    expect(useWalletStore.getState().balances).toEqual(balances);
+  });
+
+  it('setError stores and clears the error message', () => {
+    useWalletStore.getState().setError('boom');
+    expect(useWalletStore.getState().error).toBe('boom');
+
+    useWalletStore.getState().setError(null);
+    expect(useWalletStore.getState().error).toBeNull();
+  });
+
+  it('setHydrated flips hasHydrated to true', () => {
+    useWalletStore.getState().setHydrated();
+    expect(useWalletStore.getState().hasHydrated).toBe(true);
+  });
+
+  it('reset restores the initial state', () => {
+    useWalletStore.getState().setStatus('ready');
+    useWalletStore.getState().setPublicKey('GPUB');
+    useWalletStore.getState().setBalances({ xlm: '1', usdc: null, hasUsdcTrustline: false });
+    useWalletStore.getState().setError('boom');
+    useWalletStore.getState().setHydrated();
+
+    useWalletStore.getState().reset();
+
+    const state = useWalletStore.getState();
+    expect(state.status).toBe('idle');
+    expect(state.publicKey).toBeNull();
+    expect(state.balances).toBeNull();
+    expect(state.error).toBeNull();
+    expect(state.hasHydrated).toBe(false);
+  });
+});

--- a/src/features/wallet/state/walletStore.ts
+++ b/src/features/wallet/state/walletStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+
+import type { WalletBalances } from '@/features/wallet/services/BalanceService';
+
+export type WalletStatus = 'idle' | 'creating' | 'awaiting_funding' | 'ready' | 'error';
+
+interface WalletState {
+  status: WalletStatus;
+  publicKey: string | null;
+  balances: WalletBalances | null;
+  error: string | null;
+  hasHydrated: boolean;
+  setStatus: (status: WalletStatus) => void;
+  setPublicKey: (publicKey: string) => void;
+  setBalances: (balances: WalletBalances) => void;
+  setError: (error: string | null) => void;
+  setHydrated: () => void;
+  reset: () => void;
+}
+
+const INITIAL_STATE = {
+  status: 'idle' as WalletStatus,
+  publicKey: null as string | null,
+  balances: null as WalletBalances | null,
+  error: null as string | null,
+  hasHydrated: false,
+};
+
+export const useWalletStore = create<WalletState>((set) => ({
+  ...INITIAL_STATE,
+
+  setStatus: (status) => set({ status }),
+  setPublicKey: (publicKey) => set({ publicKey }),
+  setBalances: (balances) => set({ balances }),
+  setError: (error) => set({ error }),
+  setHydrated: () => set({ hasHydrated: true }),
+  reset: () => set({ ...INITIAL_STATE }),
+}));
+
+export const selectWalletStatus = (state: WalletState) => state.status;
+export const selectWalletPublicKey = (state: WalletState) => state.publicKey;

--- a/src/features/wallet/utils/formatBalance.test.ts
+++ b/src/features/wallet/utils/formatBalance.test.ts
@@ -1,0 +1,27 @@
+import { formatBalance } from './formatBalance';
+
+describe('formatBalance', () => {
+  it('formats a whole number without decimals', () => {
+    expect(formatBalance('100.0000000')).toBe('100');
+  });
+
+  it('trims trailing zeros while keeping significant decimals', () => {
+    expect(formatBalance('1234.5000000')).toBe('1,234.5');
+  });
+
+  it('caps fraction digits to the given precision', () => {
+    expect(formatBalance('10.123456', 2)).toBe('10.12');
+  });
+
+  it('accepts numeric input', () => {
+    expect(formatBalance(42)).toBe('42');
+  });
+
+  it('returns 0 for non-numeric input', () => {
+    expect(formatBalance('not-a-number')).toBe('0');
+  });
+
+  it('returns 0 for an empty string', () => {
+    expect(formatBalance('')).toBe('0');
+  });
+});

--- a/src/features/wallet/utils/formatBalance.ts
+++ b/src/features/wallet/utils/formatBalance.ts
@@ -1,0 +1,17 @@
+const DEFAULT_MAX_FRACTION_DIGITS = 4;
+
+export function formatBalance(
+  rawBalance: string | number,
+  maxFractionDigits: number = DEFAULT_MAX_FRACTION_DIGITS
+): string {
+  const value = typeof rawBalance === 'number' ? rawBalance : Number(rawBalance);
+
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+
+  return value.toLocaleString('en-US', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: maxFractionDigits,
+  });
+}

--- a/src/features/wallet/views/FundWalletView.tsx
+++ b/src/features/wallet/views/FundWalletView.tsx
@@ -1,0 +1,70 @@
+import { StyleSheet, View } from 'react-native';
+
+import { Button } from '@/components/ui/Button';
+import { Screen } from '@/components/ui/Screen';
+import { ThemedText } from '@/components/themed-text';
+import { useTheme } from '@/hooks/use-theme';
+
+export interface FundWalletViewProps {
+  publicKey: string;
+  onCheckFunding: () => void;
+  isChecking: boolean;
+}
+
+export function FundWalletView({ publicKey, onCheckFunding, isChecking }: FundWalletViewProps) {
+  const theme = useTheme();
+
+  return (
+    <Screen scrollable>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <ThemedText type="subtitle">Agrega fondos para activar tu billetera</ThemedText>
+          <ThemedText themeColor="textSecondary" style={styles.description}>
+            Tu billetera fue creada pero todavía no existe en la red. Envía XLM a esta dirección
+            para activarla.
+          </ThemedText>
+        </View>
+
+        <View style={[styles.addressCard, { backgroundColor: theme.backgroundElement }]}>
+          <ThemedText type="small" themeColor="textSecondary">
+            Dirección de tu billetera
+          </ThemedText>
+          <ThemedText type="code" selectable style={styles.addressValue}>
+            {publicKey}
+          </ThemedText>
+        </View>
+
+        <Button
+          label={isChecking ? 'Verificando…' : 'Ya envié fondos, verificar'}
+          onPress={onCheckFunding}
+          loading={isChecking}
+          accessibilityLabel="Verificar si la billetera ya recibió fondos"
+          accessibilityHint="Consulta la red Stellar para confirmar si la cuenta ya está activa"
+        />
+      </View>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 24,
+    paddingTop: 16,
+    paddingBottom: 32,
+  },
+  header: {
+    gap: 12,
+  },
+  description: {
+    lineHeight: 24,
+  },
+  addressCard: {
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+  },
+  addressValue: {
+    lineHeight: 20,
+  },
+});

--- a/src/features/wallet/views/WalletSetupView.tsx
+++ b/src/features/wallet/views/WalletSetupView.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { Button } from '@/components/ui/Button';
+import { Screen } from '@/components/ui/Screen';
+import { ThemedText } from '@/components/themed-text';
+import { useTheme } from '@/hooks/use-theme';
+import { env } from '@/lib/env';
+import { useWallet } from '@/features/wallet/hooks/useWallet';
+import { FundWalletView } from './FundWalletView';
+
+const READY_REDIRECT_DELAY_MS = 900;
+
+export function WalletSetupView() {
+  const router = useRouter();
+  const theme = useTheme();
+  const { status, publicKey, error, createWallet, checkFunding } = useWallet();
+  const [isChecking, setIsChecking] = useState(false);
+
+  useEffect(() => {
+    if (status !== 'ready') return;
+
+    const timer = setTimeout(() => {
+      router.replace('/(tabs)/receive');
+    }, READY_REDIRECT_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [status, router]);
+
+  const handleCreateWallet = useCallback(() => {
+    void createWallet();
+  }, [createWallet]);
+
+  const handleCheckFunding = useCallback(async () => {
+    setIsChecking(true);
+    await checkFunding();
+    setIsChecking(false);
+  }, [checkFunding]);
+
+  if (status === 'awaiting_funding' && publicKey) {
+    return (
+      <FundWalletView
+        publicKey={publicKey}
+        onCheckFunding={() => void handleCheckFunding()}
+        isChecking={isChecking}
+      />
+    );
+  }
+
+  return (
+    <Screen scrollable>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <ThemedText type="subtitle">Configura tu billetera</ThemedText>
+          <ThemedText themeColor="textSecondary" style={styles.description}>
+            Creamos una billetera Stellar en este dispositivo para que puedas recibir y enviar XLM y
+            USDC.
+          </ThemedText>
+        </View>
+
+        <View style={[styles.infoCard, { backgroundColor: theme.backgroundElement }]}>
+          <InfoRow icon="🔑" text="Tu llave privada nunca sale de este dispositivo" />
+          <InfoRow
+            icon="🌐"
+            text={
+              env.stellarNetwork === 'testnet'
+                ? 'Se financiará automáticamente en la red de prueba'
+                : 'Deberás depositar fondos para activarla'
+            }
+          />
+          <InfoRow icon="💵" text="USDC se habilita automáticamente cuando hay fondos" />
+        </View>
+
+        {status === 'ready' && (
+          <View style={[styles.successCard, { backgroundColor: theme.success + '20' }]}>
+            <ThemedText type="smallBold" style={{ color: theme.success }}>
+              ✓ Billetera lista
+            </ThemedText>
+            <ThemedText type="small" themeColor="textSecondary">
+              Redirigiendo…
+            </ThemedText>
+          </View>
+        )}
+
+        {status === 'error' && error && (
+          <View style={[styles.errorCard, { backgroundColor: theme.error + '20' }]}>
+            <ThemedText type="small" style={{ color: theme.error }}>
+              {error}
+            </ThemedText>
+          </View>
+        )}
+
+        {status !== 'ready' && (
+          <View style={styles.actions}>
+            <Button
+              label={
+                status === 'creating'
+                  ? 'Creando billetera…'
+                  : status === 'error'
+                    ? 'Intentar de nuevo'
+                    : 'Crear billetera'
+              }
+              onPress={handleCreateWallet}
+              loading={status === 'creating'}
+              disabled={status === 'creating'}
+              accessibilityLabel="Crear billetera Stellar"
+              accessibilityHint="Genera una billetera y la activa en la red Stellar"
+            />
+          </View>
+        )}
+      </View>
+    </Screen>
+  );
+}
+
+function InfoRow({ icon, text }: { icon: string; text: string }) {
+  return (
+    <View style={styles.infoRow} accessibilityRole="text">
+      <ThemedText style={styles.infoIcon} accessible={false}>
+        {icon}
+      </ThemedText>
+      <ThemedText type="small" themeColor="textSecondary" style={styles.infoText}>
+        {text}
+      </ThemedText>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    gap: 24,
+    paddingTop: 16,
+    paddingBottom: 32,
+  },
+  header: {
+    gap: 12,
+  },
+  description: {
+    lineHeight: 24,
+  },
+  infoCard: {
+    borderRadius: 16,
+    padding: 16,
+    gap: 12,
+  },
+  infoRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 12,
+  },
+  infoIcon: {
+    fontSize: 18,
+    lineHeight: 22,
+    width: 24,
+    textAlign: 'center',
+  },
+  infoText: {
+    flex: 1,
+    lineHeight: 20,
+  },
+  successCard: {
+    borderRadius: 12,
+    padding: 14,
+    gap: 4,
+  },
+  errorCard: {
+    borderRadius: 12,
+    padding: 14,
+  },
+  actions: {
+    gap: 12,
+    marginTop: 8,
+  },
+});

--- a/src/lib/SecureKeyStore.ts
+++ b/src/lib/SecureKeyStore.ts
@@ -25,6 +25,7 @@ import { SECURE_KEYS } from './SecureKeyStore.types';
 const AUTH_REQUIRED_KEYS: ReadonlySet<SecureKey> = new Set([
   SECURE_KEYS.PASSKEY_CREDENTIAL_ID,
   SECURE_KEYS.WALLET_PUBLIC_KEY,
+  SECURE_KEYS.WALLET_STELLAR_SECRET_KEY,
 ]);
 
 function buildOptions(

--- a/src/lib/SecureKeyStore.types.ts
+++ b/src/lib/SecureKeyStore.types.ts
@@ -16,6 +16,10 @@ export const SECURE_KEYS = {
   AUTH_STATE: 'ding.auth.state',
   /** Session timestamp of last authenticated activity */
   SESSION_LAST_ACTIVE: 'ding.session.lastActive',
+  /** Stellar account public key (StrKey G...) generated for the on-chain wallet */
+  WALLET_STELLAR_PUBLIC_KEY: 'ding.wallet.stellar.publicKey',
+  /** Stellar account secret key (StrKey S...) — never read outside signing operations */
+  WALLET_STELLAR_SECRET_KEY: 'ding.wallet.stellar.secretKey',
 } as const;
 
 export type SecureKey = (typeof SECURE_KEYS)[keyof typeof SECURE_KEYS];

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,8 +1,11 @@
+import { Networks } from '@stellar/stellar-sdk';
+
 export interface AppEnv {
   stellarNetwork: 'testnet' | 'mainnet';
   horizonUrl: string;
   rpcUrl: string;
   usdcIssuer: string;
+  networkPassphrase: string;
 }
 
 const getEnvVar = (key: string, defaultValue?: string): string => {
@@ -38,4 +41,5 @@ export const env: AppEnv = {
   horizonUrl,
   rpcUrl,
   usdcIssuer,
+  networkPassphrase: network === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET,
 };


### PR DESCRIPTION
Closes #30

## Description

Implements C08 — turns C07's (unmerged) wallet groundwork into user-facing
setup and balance flows for XLM and USDC: a `useWallet` hook, a post-passkey
wallet setup screen, testnet friendbot account creation, typed balance
parsing, automatic USDC trustline provisioning, and reusable asset
constants/selector UI for receive/send/NFC.

## Type of change

- [x] New feature (`feat`)

## Changes made

- `useWallet` hook (`src/features/wallet/hooks/useWallet.ts`) composing wallet state, account creation, and balances without exposing secrets
- `walletStore.ts` (zustand) — idle/creating/awaiting_funding/ready/error state machine
- `AccountService.ts` — keypair generation + secure persistence, testnet friendbot funding with duplicate-account handling, mainnet existence check
- `BalanceService.ts` + `formatBalance.ts` — typed XLM/USDC balance parsing (issuer-scoped) and decimal formatting
- `TrustlineService.ts` — idempotent USDC trustline ensure-flow with a reserve pre-check, safe error surfaced on failure
- `WalletSetupView` / `FundWalletView` + new `(onboarding)/wallet-setup` route, wired in right after passkey creation
- `AssetSelector` component + smoke-integrated into the Receive/Send placeholder screens
- `env.ts`: added `networkPassphrase`; `SecureKeyStore`: added dedicated Stellar keypair keys (secret key gated behind biometric auth)

## Notes for reviewers

- C07 (#24) was never actually merged (PR #26 was closed, not merged), so the wallet-core primitives this issue assumed as a prerequisite didn't exist — built the minimum needed (keygen, Horizon access) directly into C08's services, scoped to what C08 needs.
- C06 already writes a placeholder into the `WALLET_PUBLIC_KEY` secure-store key (the passkey credential ID, not a real address). To avoid colliding with that or double-prompting biometrics, this PR uses separate keys (`WALLET_STELLAR_PUBLIC_KEY` / `WALLET_STELLAR_SECRET_KEY`) for the actual Stellar keypair. Settings will keep showing the C06 placeholder until wallet readiness is wired into AuthGuard/Settings, which is C09's explicit scope (CLI-042).
- Base reserve for the trustline check is a hardcoded 0.5 XLM constant, matching the network's current base reserve — flagged as an assumption in case it drifts.
- No global Buffer/crypto polyfill exists at the app root, so wallet services self-polyfill defensively (same pattern already used by `stellar-spike.ts`) rather than touching `_layout.tsx`.

## Test plan

- [x] 41 new unit tests: balance parsing, trustline reserve math + idempotency, friendbot duplicate-account handling, wallet store transitions, `useWallet` orchestration with mocked services
- [x] Full suite passes: 86/86 tests
- [x] `npm run lint` and `npx tsc --noEmit` pass with zero errors
- [ ] Manual/device testnet run not yet performed (needs a physical device or simulator with a dev client build)

## Checklist

- [x] I included `Closes #` with the correct issue number
- [x] Code follows project conventions (`src/features/`, etc.)
- [x] `npm run lint` and `npx tsc --noEmit` pass without errors
- [ ] Tested on device/emulator (iOS and/or Android)
- [ ] Updated documentation if the change requires it